### PR TITLE
Resolve import spacing after merge

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,5 +1,6 @@
 import { streamText, convertToModelMessages } from "ai"
 import { createOpenAI } from "@ai-sdk/openai"
+
 import type { AccountItem, Transaction, FinancialGoal, StockAction } from "@/lib/portfolio-data"
 
 interface PortfolioData {


### PR DESCRIPTION
### Motivation
- Fix leftover merge/import formatting by separating external imports from internal type-only imports in `app/api/chat/route.ts` to restore a clean import ordering and avoid linter/style issues.

### Description
- Add a blank line between external imports (`streamText`, `createOpenAI`) and the internal type import from `@/lib/portfolio-data` in `app/api/chat/route.ts`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986432eb730832b96167be9c6b49d72)