### PR TITLE
Add performance & allocation overview section

### DIFF
--- a/components/kokonutui/content.tsx
+++ b/components/kokonutui/content.tsx
@@ -1,11 +1,12 @@
 "use client"
 
-import { Target, CreditCard, Wallet, Bot, TrendingUp } from "lucide-react"
+import { Target, CreditCard, Wallet, Bot, TrendingUp, PieChart } from "lucide-react"
 import List01 from "./list-01"
 import List02 from "./list-02"
 import List03 from "./list-03"
 import List04 from "./list-04"
 import AIAdvisor from "./ai-advisor"
+import PerformanceAllocation from "./performance-allocation"
 import { PortfolioProvider } from "@/lib/portfolio-context"
 
 export default function Content() {
@@ -24,7 +25,7 @@ export default function Content() {
           <AIAdvisor className="w-full" />
         </section>
 
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           <section id="accounts" className="space-y-3 scroll-mt-24">
             <div className="flex items-center gap-3">
               <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
@@ -45,6 +46,18 @@ export default function Content() {
               </h2>
             </div>
             <List02 className="h-full w-full" />
+          </section>
+
+          <section id="performance-allocation" className="space-y-3 scroll-mt-24">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+                <PieChart className="w-4 h-4 text-primary" />
+              </div>
+              <h2 className="text-sm font-semibold tracking-tight text-foreground">
+                Performance & Allocation
+              </h2>
+            </div>
+            <PerformanceAllocation className="h-full w-full" />
           </section>
         </div>
 

--- a/components/kokonutui/performance-allocation.tsx
+++ b/components/kokonutui/performance-allocation.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import { usePortfolio } from "@/lib/portfolio-context"
+
+interface PerformanceAllocationProps {
+  className?: string
+}
+
+export default function PerformanceAllocation({ className }: PerformanceAllocationProps) {
+  const { allocationActual, allocationTargets, performanceMetrics, riskMetrics } = usePortfolio()
+  const targetMap = new Map(allocationTargets.map((item) => [item.id, item.target]))
+
+  return (
+    <div className={cn("w-full fx-panel", className)}>
+      <div className="p-4 border-b border-border/60">
+        <p className="text-xs text-muted-foreground">Performance & Allocation</p>
+        <h3 className="text-base font-semibold text-foreground">
+          Vue d&apos;ensemble du portefeuille
+        </h3>
+      </div>
+
+      <div className="p-4 space-y-4 border-b border-border/60">
+        <div className="flex items-center justify-between text-xs">
+          <span className="font-medium text-foreground">Allocation réelle vs cible</span>
+          <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+            <span className="flex items-center gap-1">
+              <span className="h-2 w-2 rounded-full bg-foreground/80" />
+              Réelle
+            </span>
+            <span className="flex items-center gap-1">
+              <span className="h-2 w-2 rounded-full border border-foreground/60" />
+              Cible
+            </span>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          {allocationActual.map((item) => {
+            const target = targetMap.get(item.id) ?? 0
+            return (
+              <div key={item.id} className="space-y-2">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="font-medium text-foreground">{item.label}</span>
+                  <span className="text-muted-foreground">
+                    {item.actual}% / cible {target}%
+                  </span>
+                </div>
+                <div className="relative h-2 w-full rounded-full bg-muted">
+                  <div
+                    className={cn("h-full rounded-full", item.colorClass)}
+                    style={{ width: `${item.actual}%` }}
+                  />
+                  <div
+                    className="absolute top-0 h-full w-0.5 bg-foreground/70"
+                    style={{ left: `${target}%` }}
+                  />
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className="p-4 grid gap-3 md:grid-cols-2">
+        <div className="rounded-lg border border-border/60 bg-background/60 p-3 space-y-3">
+          <div>
+            <p className="text-xs font-semibold text-foreground">KPIs de performance</p>
+            <p className="text-[11px] text-muted-foreground">
+              Rendements clés et comparaison benchmark
+            </p>
+          </div>
+          <div className="space-y-2">
+            {performanceMetrics.map((metric) => (
+              <div key={metric.id} className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-xs font-medium text-foreground">{metric.label}</p>
+                  {metric.note && (
+                    <p className="text-[11px] text-muted-foreground">{metric.note}</p>
+                  )}
+                </div>
+                <span className="text-xs font-semibold text-foreground">{metric.value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border/60 bg-background/60 p-3 space-y-3">
+          <div>
+            <p className="text-xs font-semibold text-foreground">KPIs de risque</p>
+            <p className="text-[11px] text-muted-foreground">
+              Mesure de la stabilité et du risque
+            </p>
+          </div>
+          <div className="space-y-2">
+            {riskMetrics.map((metric) => (
+              <div key={metric.id} className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-xs font-medium text-foreground">{metric.label}</p>
+                  {metric.note && (
+                    <p className="text-[11px] text-muted-foreground">{metric.note}</p>
+                  )}
+                </div>
+                <span className="text-xs font-semibold text-foreground">{metric.value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/portfolio-context.tsx
+++ b/lib/portfolio-context.tsx
@@ -3,9 +3,17 @@
 import React, { createContext, useContext, useState, useCallback, useMemo, useEffect } from "react"
 import {
   ACCOUNTS as DEFAULT_ACCOUNTS,
+  ALLOCATION_ACTUAL as DEFAULT_ALLOCATION_ACTUAL,
+  ALLOCATION_TARGETS as DEFAULT_ALLOCATION_TARGETS,
+  PERFORMANCE_METRICS as DEFAULT_PERFORMANCE_METRICS,
+  RISK_METRICS as DEFAULT_RISK_METRICS,
   TRANSACTIONS as DEFAULT_TRANSACTIONS,
   FINANCIAL_GOALS as DEFAULT_GOALS,
   STOCK_ACTIONS as DEFAULT_STOCK_ACTIONS,
+  type AllocationActual,
+  type AllocationTarget,
+  type PerformanceMetric,
+  type RiskMetric,
   type AccountItem,
   type Transaction,
   type FinancialGoal,
@@ -136,6 +144,12 @@ interface PortfolioContextType {
   addStockAction: (action: Omit<StockAction, "id">) => void
   updateStockAction: (id: string, action: Partial<StockAction>) => void
   deleteStockAction: (id: string) => void
+
+  // Allocation + KPIs
+  allocationActual: AllocationActual[]
+  allocationTargets: AllocationTarget[]
+  performanceMetrics: PerformanceMetric[]
+  riskMetrics: RiskMetric[]
 
   // Computed values
   totalBalance: string
@@ -321,6 +335,10 @@ export function PortfolioProvider({ children }: { children: React.ReactNode }) {
       addStockAction,
       updateStockAction,
       deleteStockAction,
+      allocationActual: DEFAULT_ALLOCATION_ACTUAL,
+      allocationTargets: DEFAULT_ALLOCATION_TARGETS,
+      performanceMetrics: DEFAULT_PERFORMANCE_METRICS,
+      riskMetrics: DEFAULT_RISK_METRICS,
       totalBalance,
       lastSaved,
     }),

--- a/lib/portfolio-data.ts
+++ b/lib/portfolio-data.ts
@@ -39,6 +39,33 @@ export interface StockAction {
   status: "executed" | "pending" | "cancelled"
 }
 
+export interface AllocationActual {
+  id: string
+  label: string
+  actual: number
+  colorClass: string
+}
+
+export interface AllocationTarget {
+  id: string
+  label: string
+  target: number
+}
+
+export interface PerformanceMetric {
+  id: string
+  label: string
+  value: string
+  note?: string
+}
+
+export interface RiskMetric {
+  id: string
+  label: string
+  value: string
+  note?: string
+}
+
 export const ACCOUNTS: AccountItem[] = [
   {
     id: "1",
@@ -194,6 +221,121 @@ export const STOCK_ACTIONS: StockAction[] = [
     price: "$413.22",
     tradeDate: "Feb 25, 2026",
     status: "executed",
+  },
+]
+
+export const ALLOCATION_ACTUAL: AllocationActual[] = [
+  {
+    id: "equities",
+    label: "Actions",
+    actual: 48,
+    colorClass: "bg-emerald-500",
+  },
+  {
+    id: "bonds",
+    label: "Obligations",
+    actual: 24,
+    colorClass: "bg-blue-500",
+  },
+  {
+    id: "cash",
+    label: "Cash",
+    actual: 12,
+    colorClass: "bg-amber-500",
+  },
+  {
+    id: "crypto",
+    label: "Crypto",
+    actual: 8,
+    colorClass: "bg-purple-500",
+  },
+  {
+    id: "real-estate",
+    label: "Immobilier",
+    actual: 8,
+    colorClass: "bg-rose-500",
+  },
+]
+
+export const ALLOCATION_TARGETS: AllocationTarget[] = [
+  {
+    id: "equities",
+    label: "Actions",
+    target: 50,
+  },
+  {
+    id: "bonds",
+    label: "Obligations",
+    target: 25,
+  },
+  {
+    id: "cash",
+    label: "Cash",
+    target: 10,
+  },
+  {
+    id: "crypto",
+    label: "Crypto",
+    target: 5,
+  },
+  {
+    id: "real-estate",
+    label: "Immobilier",
+    target: 10,
+  },
+]
+
+export const PERFORMANCE_METRICS: PerformanceMetric[] = [
+  {
+    id: "ytd",
+    label: "YTD",
+    value: "+8.4%",
+    note: "vs bench +1.2%",
+  },
+  {
+    id: "one-year",
+    label: "1Y",
+    value: "+14.6%",
+    note: "vs bench +2.4%",
+  },
+  {
+    id: "five-year",
+    label: "5Y",
+    value: "+42.3%",
+    note: "annualisé 7.3%",
+  },
+  {
+    id: "annualized",
+    label: "Annualisée",
+    value: "7.3%",
+    note: "sur 5 ans",
+  },
+  {
+    id: "benchmark",
+    label: "Vs Benchmark",
+    value: "+1.8%",
+    note: "allocation cible",
+  },
+]
+
+export const RISK_METRICS: RiskMetric[] = [
+  {
+    id: "volatility",
+    label: "Volatilité",
+    value: "11.4%",
+    note: "12 mois glissants",
+  },
+  {
+    id: "max-drawdown",
+    label: "Drawdown max",
+    value: "-9.2%",
+    note: "depuis 3 ans",
+  },
+  {
+    id: "sharpe",
+    label: "Ratio de Sharpe",
+    value: "0.86",
+    note: "RF 2.1%",
   },
 ]
 


### PR DESCRIPTION
### Motivation

- Provide a visual summary of portfolio allocation (actual vs target), performance KPIs and risk KPIs for the dashboard. 
- Surface allocation/performance/risk data from the shared data store so UI components and the AI advisor can consume them.

### Description

- Added new types and datasets to `lib/portfolio-data.ts`: `AllocationActual`, `AllocationTarget`, `PerformanceMetric`, `RiskMetric` and exported constants `ALLOCATION_ACTUAL`, `ALLOCATION_TARGETS`, `PERFORMANCE_METRICS`, and `RISK_METRICS`.
- Exposed these datasets through the portfolio context by extending `lib/portfolio-context.tsx` to include `allocationActual`, `allocationTargets`, `performanceMetrics`, and `riskMetrics` (defaulted to the new constants).
- Implemented a new UI panel `components/kokonutui/performance-allocation.tsx` that renders allocation bars (actual vs target) and KPI cards for performance and risk.
- Inserted the new panel into the main dashboard grid in `components/kokonutui/content.tsx` and adjusted the grid layout to accommodate the new section.

### Testing

- Launched the dev server with `HOSTNAME=0.0.0.0 PORT=3000 pnpm dev` and Next compiled and served pages successfully despite Google Fonts fetch warnings which fell back to local fonts. 
- Ran a Playwright script that navigated to `http://127.0.0.1:3000`, scrolled to the `section#performance-allocation`, and saved a screenshot to `artifacts/performance-allocation.png`, confirming the new panel renders in the dashboard.
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698647c29108832bbb85bd7504ed06df)