### PR TITLE
Add Net Worth dashboard panel with mock history and breakdowns

### DIFF
--- a/components/kokonutui/content.tsx
+++ b/components/kokonutui/content.tsx
@@ -1,12 +1,13 @@
 "use client"
 
-import { Target, CreditCard, Wallet, Bot, TrendingUp, PieChart } from "lucide-react"
+import { Target, CreditCard, Wallet, Bot, TrendingUp, PieChart, LineChart } from "lucide-react"
 import List01 from "./list-01"
 import List02 from "./list-02"
 import List03 from "./list-03"
 import List04 from "./list-04"
 import AIAdvisor from "./ai-advisor"
 import PerformanceAllocation from "./performance-allocation"
+import NetWorth from "./net-worth"
 import { PortfolioProvider } from "@/lib/portfolio-context"
 
 export default function Content() {
@@ -71,6 +72,18 @@ export default function Content() {
             </h2>
           </div>
           <List04 className="h-full w-full" />
+        </section>
+
+        <section id="net-worth" className="space-y-3 scroll-mt-24">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+              <LineChart className="w-4 h-4 text-primary" />
+            </div>
+            <h2 className="text-sm font-semibold tracking-tight text-foreground">
+              Net Worth
+            </h2>
+          </div>
+          <NetWorth className="h-full w-full" />
         </section>
 
         <section id="goals" className="space-y-3 scroll-mt-24">

--- a/components/kokonutui/net-worth.tsx
+++ b/components/kokonutui/net-worth.tsx
@@ -1,0 +1,192 @@
+"use client"
+
+import { useMemo } from "react"
+import { cn } from "@/lib/utils"
+import { usePortfolio } from "@/lib/portfolio-context"
+
+interface NetWorthProps {
+  className?: string
+}
+
+const formatCurrency = (value: number) =>
+  `$${value.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+
+export default function NetWorth({ className }: NetWorthProps) {
+  const { netWorthHistory, assetBreakdown, liabilityBreakdown } = usePortfolio()
+
+  const assetTotal = useMemo(
+    () => assetBreakdown.reduce((sum, item) => sum + item.value, 0),
+    [assetBreakdown]
+  )
+  const liabilityTotal = useMemo(
+    () => liabilityBreakdown.reduce((sum, item) => sum + item.value, 0),
+    [liabilityBreakdown]
+  )
+  const netWorthTotal = assetTotal - liabilityTotal
+
+  const chart = useMemo(() => {
+    const values = netWorthHistory.map((point) => point.value)
+    const min = Math.min(...values)
+    const max = Math.max(...values)
+    const height = 120
+    const width = 320
+    const range = Math.max(max - min, 1)
+    const step = values.length > 1 ? width / (values.length - 1) : width
+
+    const points = values
+      .map((value, index) => {
+        const x = index * step
+        const y = height - ((value - min) / range) * height
+        return `${x},${y}`
+      })
+      .join(" ")
+
+    const area = `${points} ${width},${height} 0,${height}`
+
+    return { points, area, width, height }
+  }, [netWorthHistory])
+
+  const sparkline = useMemo(() => {
+    const values = netWorthHistory.slice(-6).map((point) => point.value)
+    const min = Math.min(...values)
+    const max = Math.max(...values)
+    const height = 32
+    const width = 120
+    const range = Math.max(max - min, 1)
+    const step = values.length > 1 ? width / (values.length - 1) : width
+
+    const points = values
+      .map((value, index) => {
+        const x = index * step
+        const y = height - ((value - min) / range) * height
+        return `${x},${y}`
+      })
+      .join(" ")
+
+    return { points, width, height }
+  }, [netWorthHistory])
+
+  return (
+    <div className={cn("w-full fx-panel", className)}>
+      <div className="flex flex-wrap items-center justify-between gap-4 border-b border-border/60 p-4">
+        <div>
+          <p className="text-xs text-muted-foreground">Net worth</p>
+          <h3 className="text-base font-semibold text-foreground">Vue d&apos;ensemble patrimoniale</h3>
+        </div>
+        <div className="flex items-center gap-4">
+          <div className="text-right">
+            <p className="text-xs text-muted-foreground">Total net</p>
+            <p className="text-lg font-semibold text-foreground">{formatCurrency(netWorthTotal)}</p>
+            <p className="text-[11px] text-emerald-500">+4.6% sur 30j</p>
+          </div>
+          <div className="rounded-lg border border-border/60 bg-background/60 p-2">
+            <svg
+              width={sparkline.width}
+              height={sparkline.height}
+              viewBox={`0 0 ${sparkline.width} ${sparkline.height}`}
+              className="text-emerald-500"
+              aria-hidden="true"
+            >
+              <polyline
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                points={sparkline.points}
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 p-4 lg:grid-cols-[2fr_1fr]">
+        <div className="space-y-4">
+          <div className="rounded-lg border border-border/60 bg-background/60 p-4">
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>Historique 12 mois</span>
+              <span>Dernière mise à jour: aujourd&apos;hui</span>
+            </div>
+            <div className="mt-4">
+              <svg
+                width="100%"
+                height={chart.height}
+                viewBox={`0 0 ${chart.width} ${chart.height}`}
+                className="overflow-visible"
+                role="img"
+                aria-label="Courbe d'évolution du net worth"
+              >
+                <polygon points={chart.area} fill="hsl(var(--primary) / 0.12)" />
+                <polyline
+                  fill="none"
+                  stroke="hsl(var(--primary))"
+                  strokeWidth="2"
+                  points={chart.points}
+                />
+              </svg>
+            </div>
+            <div className="mt-3 grid grid-cols-6 gap-2 text-[11px] text-muted-foreground">
+              {netWorthHistory.slice(-6).map((point) => (
+                <div key={point.id} className="text-center">
+                  {point.label}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div className="rounded-lg border border-border/60 bg-background/60 p-4">
+            <div className="flex items-center justify-between text-xs">
+              <span className="font-medium text-foreground">Actifs</span>
+              <span className="text-muted-foreground">{formatCurrency(assetTotal)}</span>
+            </div>
+            <div className="mt-3 space-y-3">
+              {assetBreakdown.map((item) => (
+                <div key={item.id} className="space-y-2">
+                  <div className="flex items-center justify-between text-xs">
+                    <span className="font-medium text-foreground">{item.label}</span>
+                    <span className="text-muted-foreground">{formatCurrency(item.value)}</span>
+                  </div>
+                  {item.description && (
+                    <p className="text-[11px] text-muted-foreground">{item.description}</p>
+                  )}
+                  <div className="h-1.5 w-full rounded-full bg-muted">
+                    <div
+                      className={cn("h-1.5 rounded-full", item.colorClass ?? "bg-emerald-500")}
+                      style={{ width: `${(item.value / assetTotal) * 100}%` }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-border/60 bg-background/60 p-4">
+            <div className="flex items-center justify-between text-xs">
+              <span className="font-medium text-foreground">Passifs</span>
+              <span className="text-muted-foreground">{formatCurrency(liabilityTotal)}</span>
+            </div>
+            <div className="mt-3 space-y-3">
+              {liabilityBreakdown.map((item) => (
+                <div key={item.id} className="space-y-2">
+                  <div className="flex items-center justify-between text-xs">
+                    <span className="font-medium text-foreground">{item.label}</span>
+                    <span className="text-muted-foreground">{formatCurrency(item.value)}</span>
+                  </div>
+                  {item.description && (
+                    <p className="text-[11px] text-muted-foreground">{item.description}</p>
+                  )}
+                  <div className="h-1.5 w-full rounded-full bg-muted">
+                    <div
+                      className={cn("h-1.5 rounded-full", item.colorClass ?? "bg-rose-500")}
+                      style={{ width: `${(item.value / liabilityTotal) * 100}%` }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/portfolio-context.tsx
+++ b/lib/portfolio-context.tsx
@@ -5,13 +5,18 @@ import {
   ACCOUNTS as DEFAULT_ACCOUNTS,
   ALLOCATION_ACTUAL as DEFAULT_ALLOCATION_ACTUAL,
   ALLOCATION_TARGETS as DEFAULT_ALLOCATION_TARGETS,
+  ASSET_BREAKDOWN as DEFAULT_ASSET_BREAKDOWN,
   PERFORMANCE_METRICS as DEFAULT_PERFORMANCE_METRICS,
   RISK_METRICS as DEFAULT_RISK_METRICS,
+  LIABILITY_BREAKDOWN as DEFAULT_LIABILITY_BREAKDOWN,
+  NET_WORTH_HISTORY as DEFAULT_NET_WORTH_HISTORY,
   TRANSACTIONS as DEFAULT_TRANSACTIONS,
   FINANCIAL_GOALS as DEFAULT_GOALS,
   STOCK_ACTIONS as DEFAULT_STOCK_ACTIONS,
   type AllocationActual,
   type AllocationTarget,
+  type NetWorthBreakdownItem,
+  type NetWorthHistoryPoint,
   type PerformanceMetric,
   type RiskMetric,
   type AccountItem,
@@ -150,6 +155,9 @@ interface PortfolioContextType {
   allocationTargets: AllocationTarget[]
   performanceMetrics: PerformanceMetric[]
   riskMetrics: RiskMetric[]
+  netWorthHistory: NetWorthHistoryPoint[]
+  assetBreakdown: NetWorthBreakdownItem[]
+  liabilityBreakdown: NetWorthBreakdownItem[]
 
   // Computed values
   totalBalance: string
@@ -339,6 +347,9 @@ export function PortfolioProvider({ children }: { children: React.ReactNode }) {
       allocationTargets: DEFAULT_ALLOCATION_TARGETS,
       performanceMetrics: DEFAULT_PERFORMANCE_METRICS,
       riskMetrics: DEFAULT_RISK_METRICS,
+      netWorthHistory: DEFAULT_NET_WORTH_HISTORY,
+      assetBreakdown: DEFAULT_ASSET_BREAKDOWN,
+      liabilityBreakdown: DEFAULT_LIABILITY_BREAKDOWN,
       totalBalance,
       lastSaved,
     }),

--- a/lib/portfolio-data.ts
+++ b/lib/portfolio-data.ts
@@ -66,6 +66,20 @@ export interface RiskMetric {
   note?: string
 }
 
+export interface NetWorthHistoryPoint {
+  id: string
+  label: string
+  value: number
+}
+
+export interface NetWorthBreakdownItem {
+  id: string
+  label: string
+  value: number
+  description?: string
+  colorClass?: string
+}
+
 export const ACCOUNTS: AccountItem[] = [
   {
     id: "1",
@@ -337,6 +351,76 @@ export const RISK_METRICS: RiskMetric[] = [
     value: "0.86",
     note: "RF 2.1%",
   },
+]
+
+export const ASSET_BREAKDOWN: NetWorthBreakdownItem[] = [
+  {
+    id: "cash",
+    label: "Cash",
+    description: "Comptes courants & épargne",
+    value: 12450,
+    colorClass: "bg-emerald-500",
+  },
+  {
+    id: "investments",
+    label: "Investissements",
+    description: "ETF, actions, obligations",
+    value: 38400,
+    colorClass: "bg-blue-500",
+  },
+  {
+    id: "real-estate",
+    label: "Immobilier",
+    description: "Résidence principale",
+    value: 185000,
+    colorClass: "bg-purple-500",
+  },
+  {
+    id: "other-assets",
+    label: "Autres",
+    description: "Véhicules, participations",
+    value: 12500,
+    colorClass: "bg-amber-500",
+  },
+]
+
+export const LIABILITY_BREAKDOWN: NetWorthBreakdownItem[] = [
+  {
+    id: "mortgage",
+    label: "Crédits",
+    description: "Crédit immobilier",
+    value: 142000,
+    colorClass: "bg-rose-500",
+  },
+  {
+    id: "credit-cards",
+    label: "Cartes",
+    description: "Cartes de crédit",
+    value: 5200,
+    colorClass: "bg-orange-500",
+  },
+  {
+    id: "loans",
+    label: "Prêts",
+    description: "Prêt auto & personnel",
+    value: 9800,
+    colorClass: "bg-red-500",
+  },
+]
+
+export const NET_WORTH_HISTORY: NetWorthHistoryPoint[] = [
+  { id: "jan", label: "Jan", value: 82000 },
+  { id: "feb", label: "Fév", value: 84500 },
+  { id: "mar", label: "Mar", value: 87250 },
+  { id: "apr", label: "Avr", value: 90500 },
+  { id: "may", label: "Mai", value: 93200 },
+  { id: "jun", label: "Juin", value: 96800 },
+  { id: "jul", label: "Juil", value: 100400 },
+  { id: "aug", label: "Août", value: 103250 },
+  { id: "sep", label: "Sep", value: 108900 },
+  { id: "oct", label: "Oct", value: 112600 },
+  { id: "nov", label: "Nov", value: 116300 },
+  { id: "dec", label: "Déc", value: 120150 },
 ]
 
 export const TOTAL_BALANCE = "$26,540.25"


### PR DESCRIPTION
### Motivation
- Provide a Net Worth overview panel showing asset and liability breakdowns, a total net worth, and a historical evolution chart (with mock data) to enrich the dashboard.
- Surface the net worth data through the existing portfolio context so other components can consume it.

### Description
- Added a new component `components/kokonutui/net-worth.tsx` that renders total net worth, a 12-month area/line chart, an inline sparkline, and lists of asset and liability breakdowns with progress bars.
- Extended `lib/portfolio-data.ts` with types `NetWorthHistoryPoint` and `NetWorthBreakdownItem` and provided mock data constants `NET_WORTH_HISTORY`, `ASSET_BREAKDOWN`, and `LIABILITY_BREAKDOWN`.
- Exposed the new net worth datasets from `lib/portfolio-context.tsx` by importing defaults and adding `netWorthHistory`, `assetBreakdown`, and `liabilityBreakdown` to the context value.
- Updated `components/kokonutui/content.tsx` to import and render the new `NetWorth` panel (with a `LineChart` icon) in the dashboard layout.

### Testing
- Launched the dev server with `pnpm dev`, and Next.js compiled successfully (pages `/` and `/dashboard` returned 200 responses) despite Google Fonts fetch warnings that fell back to local fonts.
- Ran a Playwright script to load the running app and capture a screenshot, which produced the artifact `artifacts/net-worth.png` successfully.
- Verified the changes were staged and committed (`git commit` completed), and the new file `components/kokonutui/net-worth.tsx` was added with other files updated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69864bc32578832bb05e6978ddda00c1)