### PR TITLE
Add Budget & Cashflow panel with forecasts and threshold alerts

### DIFF
--- a/components/kokonutui/budget-cashflow.tsx
+++ b/components/kokonutui/budget-cashflow.tsx
@@ -1,0 +1,206 @@
+"use client"
+
+import { useMemo } from "react"
+import { AlertTriangle, ArrowDownRight, ArrowUpRight } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { usePortfolio } from "@/lib/portfolio-context"
+
+interface BudgetCashflowProps {
+  className?: string
+}
+
+const formatCurrency = (value: number) =>
+  `$${value.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`
+
+const statusStyles = {
+  ok: "border-emerald-500/30 bg-emerald-500/10 text-emerald-500",
+  warning: "border-amber-500/30 bg-amber-500/10 text-amber-500",
+  critical: "border-rose-500/30 bg-rose-500/10 text-rose-500",
+} as const
+
+export default function BudgetCashflow({ className }: BudgetCashflowProps) {
+  const { budgets, cashflowForecast, alertsThresholds } = usePortfolio()
+
+  const cashflowChart = useMemo(() => {
+    const values = cashflowForecast.flatMap((point) => [point.income, point.expenses])
+    const min = Math.min(...values)
+    const max = Math.max(...values)
+    const height = 120
+    const width = 300
+    const range = Math.max(max - min, 1)
+    const step = values.length > 1 ? width / (cashflowForecast.length - 1) : width
+
+    const buildPoints = (key: "income" | "expenses") =>
+      cashflowForecast
+        .map((point, index) => {
+          const x = index * step
+          const y = height - ((point[key] - min) / range) * height
+          return `${x},${y}`
+        })
+        .join(" ")
+
+    return {
+      income: buildPoints("income"),
+      expenses: buildPoints("expenses"),
+      width,
+      height,
+    }
+  }, [cashflowForecast])
+
+  const totals = useMemo(() => {
+    const totalPlanned = budgets.reduce((sum, item) => sum + item.planned, 0)
+    const totalSpent = budgets.reduce((sum, item) => sum + item.spent, 0)
+    return { totalPlanned, totalSpent }
+  }, [budgets])
+
+  return (
+    <div className={cn("w-full fx-panel", className)}>
+      <div className="border-b border-border/60 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <p className="text-xs text-muted-foreground">Budget & cashflow</p>
+            <h3 className="text-base font-semibold text-foreground">
+              Répartition budgétaire et prévisions
+            </h3>
+          </div>
+          <div className="rounded-lg border border-border/60 bg-background/60 px-3 py-2 text-xs text-muted-foreground">
+            <div className="flex items-center gap-2">
+              <ArrowUpRight className="h-3.5 w-3.5 text-emerald-500" />
+              <span>Revenus prévus: {formatCurrency(cashflowForecast.at(-1)?.income ?? 0)}</span>
+            </div>
+            <div className="mt-1 flex items-center gap-2">
+              <ArrowDownRight className="h-3.5 w-3.5 text-rose-500" />
+              <span>Dépenses prévues: {formatCurrency(cashflowForecast.at(-1)?.expenses ?? 0)}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4 rounded-lg border border-border/60 bg-background/60 p-4">
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>Projection 6 mois</span>
+            <span>Revenus vs dépenses</span>
+          </div>
+          <div className="mt-4">
+            <svg
+              width="100%"
+              height={cashflowChart.height}
+              viewBox={`0 0 ${cashflowChart.width} ${cashflowChart.height}`}
+              className="overflow-visible"
+              role="img"
+              aria-label="Projection des revenus et dépenses"
+            >
+              <polyline
+                fill="none"
+                stroke="hsl(var(--primary))"
+                strokeWidth="2"
+                points={cashflowChart.income}
+              />
+              <polyline
+                fill="none"
+                stroke="hsl(var(--destructive))"
+                strokeWidth="2"
+                points={cashflowChart.expenses}
+              />
+            </svg>
+          </div>
+          <div className="mt-3 grid grid-cols-6 gap-2 text-[11px] text-muted-foreground">
+            {cashflowForecast.map((point) => (
+              <div key={point.id} className="text-center">
+                {point.label}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 p-4 lg:grid-cols-[2fr_1fr]">
+        <div className="space-y-4">
+          <div className="rounded-lg border border-border/60 bg-background/60 p-4">
+            <div className="flex items-center justify-between text-xs">
+              <span className="font-medium text-foreground">Répartition 50 / 30 / 20</span>
+              <span className="text-muted-foreground">
+                {formatCurrency(totals.totalSpent)} / {formatCurrency(totals.totalPlanned)}
+              </span>
+            </div>
+            <div className="mt-4 space-y-4">
+              {budgets.map((budget) => {
+                const percent = Math.min((budget.spent / budget.planned) * 100, 100)
+                return (
+                  <div key={budget.id} className="space-y-2">
+                    <div className="flex items-center justify-between text-xs">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-foreground">{budget.label}</span>
+                        <span className="rounded-full border border-border/60 px-2 py-0.5 text-[10px] text-muted-foreground">
+                          {budget.allocation}%
+                        </span>
+                      </div>
+                      <span className="text-muted-foreground">
+                        {formatCurrency(budget.spent)} / {formatCurrency(budget.planned)}
+                      </span>
+                    </div>
+                    <div className="h-2 w-full rounded-full bg-muted">
+                      <div
+                        className={cn("h-2 rounded-full", budget.colorClass)}
+                        style={{ width: `${percent}%` }}
+                      />
+                    </div>
+                    <p className="text-[11px] text-muted-foreground">
+                      {percent > 100
+                        ? "Seuil dépassé"
+                        : `Reste ${formatCurrency(Math.max(budget.planned - budget.spent, 0))}`}
+                    </p>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div className="rounded-lg border border-border/60 bg-background/60 p-4">
+            <div className="flex items-center justify-between text-xs">
+              <span className="font-medium text-foreground">Alertes seuils</span>
+              <AlertTriangle className="h-4 w-4 text-amber-500" />
+            </div>
+            <div className="mt-4 space-y-3">
+              {alertsThresholds.map((alert) => {
+                const progress = Math.min((alert.current / alert.threshold) * 100, 120)
+                return (
+                  <div key={alert.id} className="space-y-2">
+                    <div className="flex items-center justify-between text-xs">
+                      <span className="font-medium text-foreground">{alert.label}</span>
+                      <span className="text-muted-foreground">
+                        {formatCurrency(alert.current)} / {formatCurrency(alert.threshold)}
+                      </span>
+                    </div>
+                    {alert.description && (
+                      <p className="text-[11px] text-muted-foreground">{alert.description}</p>
+                    )}
+                    <div className="h-1.5 w-full rounded-full bg-muted">
+                      <div
+                        className={cn("h-1.5 rounded-full", statusStyles[alert.status])}
+                        style={{ width: `${progress}%` }}
+                      />
+                    </div>
+                    <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+                      <span>
+                        {alert.status === "critical"
+                          ? "Dépassement"
+                          : alert.status === "warning"
+                            ? "Proche du seuil"
+                            : "Sous contrôle"}
+                      </span>
+                      <span className={cn("rounded-full border px-2 py-0.5", statusStyles[alert.status])}>
+                        {alert.status.toUpperCase()}
+                      </span>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/kokonutui/content.tsx
+++ b/components/kokonutui/content.tsx
@@ -1,6 +1,15 @@
 "use client"
 
-import { Target, CreditCard, Wallet, Bot, TrendingUp, PieChart, LineChart } from "lucide-react"
+import {
+  Target,
+  CreditCard,
+  Wallet,
+  Bot,
+  TrendingUp,
+  PieChart,
+  LineChart,
+  PiggyBank,
+} from "lucide-react"
 import List01 from "./list-01"
 import List02 from "./list-02"
 import List03 from "./list-03"
@@ -8,6 +17,7 @@ import List04 from "./list-04"
 import AIAdvisor from "./ai-advisor"
 import PerformanceAllocation from "./performance-allocation"
 import NetWorth from "./net-worth"
+import BudgetCashflow from "./budget-cashflow"
 import { PortfolioProvider } from "@/lib/portfolio-context"
 
 export default function Content() {
@@ -72,6 +82,18 @@ export default function Content() {
             </h2>
           </div>
           <List04 className="h-full w-full" />
+        </section>
+
+        <section id="budget-cashflow" className="space-y-3 scroll-mt-24">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+              <PiggyBank className="w-4 h-4 text-primary" />
+            </div>
+            <h2 className="text-sm font-semibold tracking-tight text-foreground">
+              Budget & Cashflow
+            </h2>
+          </div>
+          <BudgetCashflow className="w-full" />
         </section>
 
         <section id="net-worth" className="space-y-3 scroll-mt-24">

--- a/lib/portfolio-context.tsx
+++ b/lib/portfolio-context.tsx
@@ -6,6 +6,8 @@ import {
   ALLOCATION_ACTUAL as DEFAULT_ALLOCATION_ACTUAL,
   ALLOCATION_TARGETS as DEFAULT_ALLOCATION_TARGETS,
   ASSET_BREAKDOWN as DEFAULT_ASSET_BREAKDOWN,
+  BUDGETS as DEFAULT_BUDGETS,
+  CASHFLOW_FORECAST as DEFAULT_CASHFLOW_FORECAST,
   PERFORMANCE_METRICS as DEFAULT_PERFORMANCE_METRICS,
   RISK_METRICS as DEFAULT_RISK_METRICS,
   LIABILITY_BREAKDOWN as DEFAULT_LIABILITY_BREAKDOWN,
@@ -13,6 +15,7 @@ import {
   TRANSACTIONS as DEFAULT_TRANSACTIONS,
   FINANCIAL_GOALS as DEFAULT_GOALS,
   STOCK_ACTIONS as DEFAULT_STOCK_ACTIONS,
+  ALERTS_THRESHOLDS as DEFAULT_ALERTS_THRESHOLDS,
   type AllocationActual,
   type AllocationTarget,
   type NetWorthBreakdownItem,
@@ -23,6 +26,9 @@ import {
   type Transaction,
   type FinancialGoal,
   type StockAction,
+  type BudgetCategory,
+  type CashflowForecastPoint,
+  type AlertThreshold,
 } from "./portfolio-data"
 
 // LocalStorage keys for persistence
@@ -158,6 +164,9 @@ interface PortfolioContextType {
   netWorthHistory: NetWorthHistoryPoint[]
   assetBreakdown: NetWorthBreakdownItem[]
   liabilityBreakdown: NetWorthBreakdownItem[]
+  budgets: BudgetCategory[]
+  cashflowForecast: CashflowForecastPoint[]
+  alertsThresholds: AlertThreshold[]
 
   // Computed values
   totalBalance: string
@@ -350,6 +359,9 @@ export function PortfolioProvider({ children }: { children: React.ReactNode }) {
       netWorthHistory: DEFAULT_NET_WORTH_HISTORY,
       assetBreakdown: DEFAULT_ASSET_BREAKDOWN,
       liabilityBreakdown: DEFAULT_LIABILITY_BREAKDOWN,
+      budgets: DEFAULT_BUDGETS,
+      cashflowForecast: DEFAULT_CASHFLOW_FORECAST,
+      alertsThresholds: DEFAULT_ALERTS_THRESHOLDS,
       totalBalance,
       lastSaved,
     }),

--- a/lib/portfolio-data.ts
+++ b/lib/portfolio-data.ts
@@ -80,6 +80,31 @@ export interface NetWorthBreakdownItem {
   colorClass?: string
 }
 
+export interface BudgetCategory {
+  id: string
+  label: string
+  allocation: number
+  planned: number
+  spent: number
+  colorClass: string
+}
+
+export interface CashflowForecastPoint {
+  id: string
+  label: string
+  income: number
+  expenses: number
+}
+
+export interface AlertThreshold {
+  id: string
+  label: string
+  description?: string
+  threshold: number
+  current: number
+  status: "ok" | "warning" | "critical"
+}
+
 export const ACCOUNTS: AccountItem[] = [
   {
     id: "1",
@@ -421,6 +446,69 @@ export const NET_WORTH_HISTORY: NetWorthHistoryPoint[] = [
   { id: "oct", label: "Oct", value: 112600 },
   { id: "nov", label: "Nov", value: 116300 },
   { id: "dec", label: "Déc", value: 120150 },
+]
+
+export const BUDGETS: BudgetCategory[] = [
+  {
+    id: "essentials",
+    label: "Essentiels",
+    allocation: 50,
+    planned: 3200,
+    spent: 2980,
+    colorClass: "bg-emerald-500",
+  },
+  {
+    id: "lifestyle",
+    label: "Style de vie",
+    allocation: 30,
+    planned: 1900,
+    spent: 2140,
+    colorClass: "bg-amber-500",
+  },
+  {
+    id: "savings",
+    label: "Épargne",
+    allocation: 20,
+    planned: 1300,
+    spent: 980,
+    colorClass: "bg-blue-500",
+  },
+]
+
+export const CASHFLOW_FORECAST: CashflowForecastPoint[] = [
+  { id: "apr", label: "Avr", income: 5200, expenses: 4020 },
+  { id: "may", label: "Mai", income: 5300, expenses: 4175 },
+  { id: "jun", label: "Juin", income: 5400, expenses: 4280 },
+  { id: "jul", label: "Juil", income: 5250, expenses: 4410 },
+  { id: "aug", label: "Août", income: 5500, expenses: 4525 },
+  { id: "sep", label: "Sep", income: 5600, expenses: 4380 },
+]
+
+export const ALERTS_THRESHOLDS: AlertThreshold[] = [
+  {
+    id: "dining",
+    label: "Restaurants & sorties",
+    description: "Seuil mensuel",
+    threshold: 650,
+    current: 720,
+    status: "critical",
+  },
+  {
+    id: "subscriptions",
+    label: "Abonnements",
+    description: "Seuil mensuel",
+    threshold: 120,
+    current: 95,
+    status: "ok",
+  },
+  {
+    id: "shopping",
+    label: "Shopping",
+    description: "Seuil mensuel",
+    threshold: 500,
+    current: 460,
+    status: "warning",
+  },
 ]
 
 export const TOTAL_BALANCE = "$26,540.25"


### PR DESCRIPTION
### Motivation

- Provide a dedicated Budget & Cashflow dashboard panel to show a 50/30/20-style budget breakdown, simple future income vs expense projections, and per-category threshold alerts. 
- Surface budget and cashflow data from the centralized portfolio dataset so other UI and AI features can access them. 
- Integrate the new section into the main dashboard layout for immediate visibility.

### Description

- Added a new UI component `components/kokonutui/budget-cashflow.tsx` that renders allocation bars, a 6-month income vs expenses SVG chart, and threshold alert widgets. 
- Extended `lib/portfolio-data.ts` with new types and fixtures: `BudgetCategory`, `CashflowForecastPoint`, `AlertThreshold`, and exported constants `BUDGETS`, `CASHFLOW_FORECAST`, and `ALERTS_THRESHOLDS`. 
- Exposed the new data in the app context by updating `lib/portfolio-context.tsx` to include `budgets`, `cashflowForecast`, and `alertsThresholds` in the `PortfolioProvider` value. 
- Inserted the `BudgetCashflow` section into the dashboard at `components/kokonutui/content.tsx` and added an icon for the section.

### Testing

- Launched the dev server with `pnpm dev` and confirmed the app compiled despite Google Fonts fetch warnings (fallback fonts used). 
- Exercised the new UI by navigating the running app with a Playwright script which captured a full-page screenshot (`artifacts/budget-cashflow.png`), demonstrating the section renders without runtime errors. 
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69864de60288832b8431b4768e7ebac6)