### PR TITLE
Add rebalancing insights panel and diversification breakdown

### DIFF
--- a/components/kokonutui/content.tsx
+++ b/components/kokonutui/content.tsx
@@ -10,6 +10,7 @@ import {
   LineChart,
   PiggyBank,
   ClipboardList,
+  RefreshCcw,
 } from "lucide-react"
 import List01 from "./list-01"
 import List02 from "./list-02"
@@ -17,6 +18,7 @@ import List03 from "./list-03"
 import List04 from "./list-04"
 import AIAdvisor from "./ai-advisor"
 import PerformanceAllocation from "./performance-allocation"
+import Rebalancing from "./rebalancing"
 import NetWorth from "./net-worth"
 import BudgetCashflow from "./budget-cashflow"
 import PlanningScenarios from "./planning-scenarios"
@@ -84,6 +86,18 @@ export default function Content() {
             </h2>
           </div>
           <List04 className="h-full w-full" />
+        </section>
+
+        <section id="rebalancing" className="space-y-3 scroll-mt-24">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+              <RefreshCcw className="w-4 h-4 text-primary" />
+            </div>
+            <h2 className="text-sm font-semibold tracking-tight text-foreground">
+              Rééquilibrage
+            </h2>
+          </div>
+          <Rebalancing className="w-full" />
         </section>
 
         <section id="budget-cashflow" className="space-y-3 scroll-mt-24">

--- a/components/kokonutui/rebalancing.tsx
+++ b/components/kokonutui/rebalancing.tsx
@@ -1,0 +1,161 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import { usePortfolio } from "@/lib/portfolio-context"
+
+interface RebalancingProps {
+  className?: string
+}
+
+const statusStyles = {
+  overweight: "border-rose-500/30 bg-rose-500/10 text-rose-600",
+  underweight: "border-amber-500/30 bg-amber-500/10 text-amber-600",
+  balanced: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600",
+}
+
+export default function Rebalancing({ className }: RebalancingProps) {
+  const { allocationActual, allocationTargets, diversificationBreakdown } = usePortfolio()
+  const targetMap = new Map(allocationTargets.map((item) => [item.id, item.target]))
+
+  return (
+    <div className={cn("w-full fx-panel", className)}>
+      <div className="p-4 border-b border-border/60">
+        <p className="text-xs text-muted-foreground">Rebalancing</p>
+        <h3 className="text-base font-semibold text-foreground">
+          Allocation cible, actions &amp; diversification
+        </h3>
+      </div>
+
+      <div className="p-4 border-b border-border/60 space-y-4">
+        <div className="flex items-center justify-between text-xs">
+          <span className="font-medium text-foreground">Allocation cible vs actuelle</span>
+          <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+            <span className="flex items-center gap-1">
+              <span className="h-2 w-2 rounded-full bg-foreground/80" />
+              Actuelle
+            </span>
+            <span className="flex items-center gap-1">
+              <span className="h-2 w-2 rounded-full border border-foreground/60" />
+              Cible
+            </span>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          {allocationActual.map((item) => {
+            const target = targetMap.get(item.id) ?? 0
+            const delta = item.actual - target
+            const deltaLabel = delta > 0 ? `+${delta}%` : `${delta}%`
+            return (
+              <div key={item.id} className="space-y-2">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="font-medium text-foreground">{item.label}</span>
+                  <span className="text-muted-foreground">
+                    {item.actual}% / cible {target}% ({deltaLabel})
+                  </span>
+                </div>
+                <div className="relative h-2 w-full rounded-full bg-muted">
+                  <div
+                    className={cn("h-full rounded-full", item.colorClass)}
+                    style={{ width: `${item.actual}%` }}
+                  />
+                  <div
+                    className="absolute top-0 h-full w-0.5 bg-foreground/70"
+                    style={{ left: `${target}%` }}
+                  />
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className="grid gap-4 p-4 lg:grid-cols-[1.1fr_1.4fr]">
+        <div className="rounded-lg border border-border/60 bg-background/60 p-4 space-y-3">
+          <div>
+            <p className="text-xs font-semibold text-foreground">Suggestions d&apos;actions</p>
+            <p className="text-[11px] text-muted-foreground">
+              Ajustements proposés pour revenir à la cible.
+            </p>
+          </div>
+          <div className="space-y-3">
+            {diversificationBreakdown.actions.map((action) => (
+              <div key={action.id} className="rounded-lg border border-border/60 bg-background/80 p-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-semibold text-foreground">{action.title}</p>
+                    <p className="text-[11px] text-muted-foreground">{action.description}</p>
+                  </div>
+                  <span
+                    className={cn(
+                      "rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase",
+                      statusStyles[action.status]
+                    )}
+                  >
+                    {action.status === "overweight" && "Surpondéré"}
+                    {action.status === "underweight" && "Sous-pondéré"}
+                    {action.status === "balanced" && "Aligné"}
+                  </span>
+                </div>
+                <div className="mt-2 flex items-center justify-between text-[11px] text-muted-foreground">
+                  <span>Impact estimé</span>
+                  <span className="font-medium text-foreground">{action.impact}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border/60 bg-background/60 p-4 space-y-4">
+          <div>
+            <p className="text-xs font-semibold text-foreground">Analyse diversification</p>
+            <p className="text-[11px] text-muted-foreground">
+              Vue par secteur, zone et devise.
+            </p>
+          </div>
+          <div className="space-y-4">
+            {diversificationBreakdown.analysis.map((group) => (
+              <div key={group.id} className="rounded-lg border border-border/60 bg-background/80 p-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-semibold text-foreground">{group.title}</p>
+                    <p className="text-[11px] text-muted-foreground">{group.description}</p>
+                  </div>
+                </div>
+                <div className="mt-3 space-y-3">
+                  {group.items.map((item) => (
+                    <div key={item.id} className="space-y-2">
+                      <div className="flex items-center justify-between text-xs">
+                        <div>
+                          <span className="font-medium text-foreground">{item.label}</span>
+                          {item.note && (
+                            <span className="ml-2 text-[11px] text-muted-foreground">
+                              {item.note}
+                            </span>
+                          )}
+                        </div>
+                        <span className="text-muted-foreground">
+                          {item.current}% / {item.target}%
+                        </span>
+                      </div>
+                      <div className="relative h-2 w-full rounded-full bg-muted">
+                        <div
+                          className="h-full rounded-full bg-primary/70"
+                          style={{ width: `${item.current}%` }}
+                        />
+                        <div
+                          className="absolute top-0 h-full w-0.5 bg-foreground/70"
+                          style={{ left: `${item.target}%` }}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/portfolio-context.tsx
+++ b/lib/portfolio-context.tsx
@@ -8,6 +8,7 @@ import {
   ASSET_BREAKDOWN as DEFAULT_ASSET_BREAKDOWN,
   BUDGETS as DEFAULT_BUDGETS,
   CASHFLOW_FORECAST as DEFAULT_CASHFLOW_FORECAST,
+  DIVERSIFICATION_BREAKDOWN as DEFAULT_DIVERSIFICATION_BREAKDOWN,
   PERFORMANCE_METRICS as DEFAULT_PERFORMANCE_METRICS,
   RISK_METRICS as DEFAULT_RISK_METRICS,
   LIABILITY_BREAKDOWN as DEFAULT_LIABILITY_BREAKDOWN,
@@ -31,6 +32,7 @@ import {
   type CashflowForecastPoint,
   type AlertThreshold,
   type PlanningScenario,
+  type DiversificationBreakdown,
 } from "./portfolio-data"
 
 // LocalStorage keys for persistence
@@ -161,6 +163,7 @@ interface PortfolioContextType {
   // Allocation + KPIs
   allocationActual: AllocationActual[]
   allocationTargets: AllocationTarget[]
+  diversificationBreakdown: DiversificationBreakdown
   performanceMetrics: PerformanceMetric[]
   riskMetrics: RiskMetric[]
   netWorthHistory: NetWorthHistoryPoint[]
@@ -357,6 +360,7 @@ export function PortfolioProvider({ children }: { children: React.ReactNode }) {
       deleteStockAction,
       allocationActual: DEFAULT_ALLOCATION_ACTUAL,
       allocationTargets: DEFAULT_ALLOCATION_TARGETS,
+      diversificationBreakdown: DEFAULT_DIVERSIFICATION_BREAKDOWN,
       performanceMetrics: DEFAULT_PERFORMANCE_METRICS,
       riskMetrics: DEFAULT_RISK_METRICS,
       netWorthHistory: DEFAULT_NET_WORTH_HISTORY,

--- a/lib/portfolio-data.ts
+++ b/lib/portfolio-data.ts
@@ -52,6 +52,34 @@ export interface AllocationTarget {
   target: number
 }
 
+export interface DiversificationItem {
+  id: string
+  label: string
+  current: number
+  target: number
+  note?: string
+}
+
+export interface RebalancingAction {
+  id: string
+  title: string
+  description: string
+  status: "overweight" | "underweight" | "balanced"
+  impact: string
+}
+
+export interface DiversificationGroup {
+  id: string
+  title: string
+  description: string
+  items: DiversificationItem[]
+}
+
+export interface DiversificationBreakdown {
+  actions: RebalancingAction[]
+  analysis: DiversificationGroup[]
+}
+
 export interface PerformanceMetric {
   id: string
   label: string
@@ -332,6 +360,67 @@ export const ALLOCATION_TARGETS: AllocationTarget[] = [
     target: 10,
   },
 ]
+
+export const DIVERSIFICATION_BREAKDOWN: DiversificationBreakdown = {
+  actions: [
+    {
+      id: "trim-tech",
+      title: "Réduire la surpondération Tech",
+      description: "Vendre 3% d'ETF growth US pour revenir à la cible.",
+      status: "overweight",
+      impact: "-3% actions growth",
+    },
+    {
+      id: "boost-europe",
+      title: "Renforcer l'Europe",
+      description: "Acheter des ETF Europe large cap pour couvrir le déficit régional.",
+      status: "underweight",
+      impact: "+4% zone euro",
+    },
+    {
+      id: "rebalance-cash",
+      title: "Reconstituer le coussin de liquidité",
+      description: "Allouer 2% en cash pour améliorer la flexibilité.",
+      status: "underweight",
+      impact: "+2% cash",
+    },
+  ],
+  analysis: [
+    {
+      id: "sectors",
+      title: "Secteurs",
+      description: "Répartition par secteurs d'activité.",
+      items: [
+        { id: "tech", label: "Technologie", current: 32, target: 25, note: "Surpondéré" },
+        { id: "health", label: "Santé", current: 12, target: 15, note: "À renforcer" },
+        { id: "industrials", label: "Industrie", current: 10, target: 12, note: "À renforcer" },
+        { id: "consumer", label: "Consommation", current: 18, target: 18, note: "Aligné" },
+      ],
+    },
+    {
+      id: "regions",
+      title: "Zones",
+      description: "Exposition géographique globale.",
+      items: [
+        { id: "north-america", label: "Amérique du Nord", current: 58, target: 50, note: "Surpondéré" },
+        { id: "europe", label: "Europe", current: 22, target: 26, note: "À renforcer" },
+        { id: "asia", label: "Asie-Pacifique", current: 14, target: 18, note: "À renforcer" },
+        { id: "emerging", label: "Émergents", current: 6, target: 6, note: "Aligné" },
+      ],
+    },
+    {
+      id: "currencies",
+      title: "Devises",
+      description: "Répartition des expositions par devise.",
+      items: [
+        { id: "usd", label: "USD", current: 62, target: 55, note: "Surpondéré" },
+        { id: "eur", label: "EUR", current: 24, target: 28, note: "À renforcer" },
+        { id: "gbp", label: "GBP", current: 6, target: 7, note: "Légèrement bas" },
+        { id: "jpy", label: "JPY", current: 4, target: 5, note: "À renforcer" },
+      ],
+    },
+  ],
+}
 
 export const PERFORMANCE_METRICS: PerformanceMetric[] = [
   {


### PR DESCRIPTION
### Motivation

- Provide a rebalancing UI that compares target vs actual allocation and suggests concrete actions to return to target.
- Surface a diversification analysis by sector/region/currency to help diagnose sources of overweight/underweight exposures.

### Description

- Add `components/kokonutui/rebalancing.tsx` which renders allocation target vs actual bars, suggested rebalancing actions, and diversification analysis panels.
- Extend `lib/portfolio-data.ts` with new types (`DiversificationItem`, `RebalancingAction`, `DiversificationGroup`, `DiversificationBreakdown`) and a `DIVERSIFICATION_BREAKDOWN` sample dataset.
- Expose the new `diversificationBreakdown` from `lib/portfolio-context.tsx` and wire it into the provider as `DEFAULT_DIVERSIFICATION_BREAKDOWN`.
- Add the Rebalancing section to the main UI in `components/kokonutui/content.tsx` and import the new icon and component.

### Testing

- Started the dev server with `HOSTNAME=0.0.0.0 PORT=3000 pnpm dev` and Next compiled and served pages successfully (server ready).
- Captured a UI screenshot by running a Playwright script which navigated to the app and saved `artifacts/rebalancing-section.png` (screenshot created).
- Build emitted font download warnings for Google Fonts but fell back to system fonts and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698651504c54832bbde17a745393f293)