### PR TITLE
Add integrations section with mock connect CTAs

### DIFF
--- a/components/kokonutui/content.tsx
+++ b/components/kokonutui/content.tsx
@@ -11,6 +11,7 @@ import {
   PiggyBank,
   ClipboardList,
   RefreshCcw,
+  Plug,
 } from "lucide-react"
 import List01 from "./list-01"
 import List02 from "./list-02"
@@ -22,6 +23,7 @@ import Rebalancing from "./rebalancing"
 import NetWorth from "./net-worth"
 import BudgetCashflow from "./budget-cashflow"
 import PlanningScenarios from "./planning-scenarios"
+import Integrations from "./integrations"
 import { PortfolioProvider } from "@/lib/portfolio-context"
 
 export default function Content() {
@@ -122,6 +124,18 @@ export default function Content() {
             </h2>
           </div>
           <PlanningScenarios className="w-full" />
+        </section>
+
+        <section id="integrations" className="space-y-3 scroll-mt-24">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+              <Plug className="w-4 h-4 text-primary" />
+            </div>
+            <h2 className="text-sm font-semibold tracking-tight text-foreground">
+              Intégrations & synchronisation
+            </h2>
+          </div>
+          <Integrations />
         </section>
 
         <section id="net-worth" className="space-y-3 scroll-mt-24">

--- a/components/kokonutui/integrations.tsx
+++ b/components/kokonutui/integrations.tsx
@@ -1,0 +1,113 @@
+"use client"
+
+import { Cloud, Database, ShieldCheck, Plug } from "lucide-react"
+
+const integrations = [
+  {
+    name: "Plaid",
+    category: "Banques & comptes",
+    description: "Connexion sécurisée aux banques pour synchroniser les soldes.",
+    status: "Disponible",
+    accent: "text-emerald-500",
+  },
+  {
+    name: "Stripe",
+    category: "Paiements",
+    description: "Importer les flux de paiements et revenus récurrents.",
+    status: "Disponible",
+    accent: "text-sky-500",
+  },
+  {
+    name: "Bourse Direct",
+    category: "Courtage",
+    description: "Suivre les portefeuilles titres et mouvements d'actions.",
+    status: "Disponible",
+    accent: "text-violet-500",
+  },
+]
+
+const futureServices = [
+  {
+    title: "Service API de synchronisation",
+    description:
+      "Un service centralisé pour orchestrer la sync des données multi-comptes et consolider les flux.",
+  },
+  {
+    title: "Coffre-fort de tokens",
+    description:
+      "Gestion sécurisée des accès OAuth pour les intégrations futures et historiques.",
+  },
+]
+
+export default function Integrations() {
+  return (
+    <div className="fx-panel">
+      <div className="p-4 border-b border-border/60 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+            <Plug className="w-4 h-4 text-primary" />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-foreground">Intégrations connectées</h3>
+            <p className="text-xs text-muted-foreground">
+              Centralisez les comptes financiers et activez la sync automatisée.
+            </p>
+          </div>
+        </div>
+        <span className="text-[11px] font-medium text-muted-foreground">Mock v0</span>
+      </div>
+
+      <div className="p-4 space-y-3">
+        {integrations.map((integration) => (
+          <div
+            key={integration.name}
+            className="flex flex-col gap-3 rounded-xl border border-border/60 bg-background/60 p-4 lg:flex-row lg:items-center lg:justify-between"
+          >
+            <div className="flex items-start gap-3">
+              <div className="rounded-lg border border-border/60 bg-accent/40 p-2">
+                <Cloud className="h-4 w-4 text-primary" />
+              </div>
+              <div>
+                <p className="text-xs font-semibold text-foreground">{integration.name}</p>
+                <p className="text-[11px] text-muted-foreground">{integration.category}</p>
+                <p className="text-xs text-foreground/80">{integration.description}</p>
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="flex items-center gap-2 rounded-full border border-border/60 bg-accent/40 px-2.5 py-1 text-[11px] text-muted-foreground">
+                <span className={`h-2 w-2 rounded-full ${integration.accent}`} />
+                {integration.status}
+              </div>
+              <button
+                type="button"
+                className="inline-flex items-center gap-2 rounded-lg border border-border/60 bg-primary px-3 py-2 text-xs font-semibold text-primary-foreground shadow-sm transition hover:bg-primary/90"
+              >
+                <ShieldCheck className="h-3.5 w-3.5" />
+                Connecter
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="border-t border-border/60 bg-accent/20 p-4">
+        <div className="flex items-center gap-2 text-xs font-semibold text-foreground">
+          <Database className="h-4 w-4 text-primary" />
+          Roadmap sync & API
+        </div>
+        <div className="mt-3 grid gap-3 md:grid-cols-2">
+          {futureServices.map((service) => (
+            <div
+              key={service.title}
+              className="rounded-xl border border-dashed border-border/70 bg-background/40 p-3"
+            >
+              <p className="text-xs font-semibold text-foreground">{service.title}</p>
+              <p className="text-[11px] text-muted-foreground">{service.description}</p>
+              <p className="mt-2 text-[11px] font-medium text-primary">Prochainement</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/kokonutui/sidebar.tsx
+++ b/components/kokonutui/sidebar.tsx
@@ -15,6 +15,7 @@ import {
   PiggyBank,
   Target,
   Home,
+  Plug,
 } from "lucide-react"
 import Link from "next/link"
 import { useState } from "react"
@@ -123,6 +124,9 @@ export default function Sidebar() {
                   </NavItem>
                   <NavItem href="#transactions" icon={CreditCard}>
                     Budgets
+                  </NavItem>
+                  <NavItem href="#integrations" icon={Plug}>
+                    Intégrations
                   </NavItem>
                 </div>
               </div>


### PR DESCRIPTION
### Motivation
- Provide a dedicated UI surface to list external integrations and allow users to connect accounts (initially mocked). 
- Prepare space and copy for a future centralized sync API and secure token vault to consolidate multi-account data. 

### Description
- Add `components/kokonutui/integrations.tsx` to render an integrations panel with mock "Connecter" CTAs and a roadmap area for sync/API services. 
- Wire the new integrations panel into the dashboard by importing and mounting it in `components/kokonutui/content.tsx` under the `#integrations` anchor. 
- Add an "Intégrations" navigation entry to `components/kokonutui/sidebar.tsx` so the dashboard sidebar links to the new section. 

### Testing
- Started the dev server with `pnpm dev` and Next reported `Ready` (local server at `http://localhost:3000`). 
- Ran a Playwright script that loaded `/dashboard`, scrolled to `#integrations`, and saved a full-page screenshot which completed successfully (artifact: integrations.png).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698661f9eb8c832bad1aa132b689a9b7)