### PR TITLE
Add portfolio alerts widget and surface alerts in TopNav

### DIFF
--- a/components/kokonutui/alerts.tsx
+++ b/components/kokonutui/alerts.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import { usePortfolio } from "@/lib/portfolio-context"
+import { ArrowDownRight, TrendingDown, Wallet } from "lucide-react"
+
+interface AlertsProps {
+  className?: string
+}
+
+const statusStyles = {
+  actif: "border-blue-500/30 bg-blue-500/10 text-blue-600",
+  résolu: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600",
+  critique: "border-rose-500/30 bg-rose-500/10 text-rose-600",
+}
+
+const statusLabels = {
+  actif: "Actif",
+  résolu: "Résolu",
+  critique: "Critique",
+}
+
+const categoryMeta = {
+  prix: {
+    label: "Prix",
+    icon: TrendingDown,
+    styles: "bg-amber-500/10 text-amber-500",
+  },
+  "cash buffer": {
+    label: "Cash buffer",
+    icon: Wallet,
+    styles: "bg-emerald-500/10 text-emerald-500",
+  },
+  drawdown: {
+    label: "Drawdown",
+    icon: ArrowDownRight,
+    styles: "bg-rose-500/10 text-rose-500",
+  },
+}
+
+export default function Alerts({ className }: AlertsProps) {
+  const { alerts } = usePortfolio()
+  const criticalCount = alerts.filter((alert) => alert.status === "critique").length
+  const activeCount = alerts.filter((alert) => alert.status === "actif").length
+
+  return (
+    <div className={cn("w-full fx-panel", className)}>
+      <div className="flex items-center justify-between border-b border-border/60 p-4">
+        <div>
+          <p className="text-xs text-muted-foreground">Alertes portefeuille</p>
+          <h3 className="text-base font-semibold text-foreground">
+            {alerts.length} alertes à surveiller
+          </h3>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="rounded-full border border-rose-500/30 bg-rose-500/10 px-2 py-0.5 text-[10px] font-semibold text-rose-600">
+            {criticalCount} critique{criticalCount > 1 ? "s" : ""}
+          </span>
+          <span className="rounded-full border border-blue-500/30 bg-blue-500/10 px-2 py-0.5 text-[10px] font-semibold text-blue-600">
+            {activeCount} actif{activeCount > 1 ? "s" : ""}
+          </span>
+        </div>
+      </div>
+
+      <div className="space-y-3 p-4">
+        {alerts.map((alert) => {
+          const meta = categoryMeta[alert.category]
+          const Icon = meta.icon
+          return (
+            <div
+              key={alert.id}
+              className="rounded-lg border border-border/60 bg-background/70 p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex items-start gap-3">
+                  <div className={cn("rounded-lg p-2", meta.styles)}>
+                    <Icon className="h-4 w-4" />
+                  </div>
+                  <div>
+                    <p className="text-xs font-semibold text-foreground">{alert.title}</p>
+                    <p className="text-[11px] text-muted-foreground">{alert.description}</p>
+                    <div className="mt-2 flex items-center gap-2 text-[10px] text-muted-foreground">
+                      <span>{meta.label}</span>
+                      <span>•</span>
+                      <span>{alert.updatedAt}</span>
+                    </div>
+                  </div>
+                </div>
+                <span
+                  className={cn(
+                    "rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase",
+                    statusStyles[alert.status]
+                  )}
+                >
+                  {statusLabels[alert.status]}
+                </span>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/components/kokonutui/content.tsx
+++ b/components/kokonutui/content.tsx
@@ -12,6 +12,7 @@ import {
   ClipboardList,
   RefreshCcw,
   Plug,
+  AlertTriangle,
 } from "lucide-react"
 import List01 from "./list-01"
 import List02 from "./list-02"
@@ -24,6 +25,7 @@ import NetWorth from "./net-worth"
 import BudgetCashflow from "./budget-cashflow"
 import PlanningScenarios from "./planning-scenarios"
 import Integrations from "./integrations"
+import Alerts from "./alerts"
 import { PortfolioProvider } from "@/lib/portfolio-context"
 
 export default function Content() {
@@ -40,6 +42,16 @@ export default function Content() {
             </h2>
           </div>
           <AIAdvisor className="w-full" />
+        </section>
+
+        <section id="alerts" className="space-y-3 scroll-mt-24">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+              <AlertTriangle className="w-4 h-4 text-primary" />
+            </div>
+            <h2 className="text-sm font-semibold tracking-tight text-foreground">Alertes clés</h2>
+          </div>
+          <Alerts className="w-full" />
         </section>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/components/kokonutui/top-nav.tsx
+++ b/components/kokonutui/top-nav.tsx
@@ -2,10 +2,11 @@
 
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import Image from "next/image"
-import { Bell, ChevronRight } from "lucide-react"
+import { AlertTriangle, Bell, ChevronRight } from "lucide-react"
 import Profile01 from "./profile-01"
 import Link from "next/link"
 import { ThemeToggle } from "../theme-toggle"
+import { ALERTS } from "@/lib/portfolio-data"
 
 interface BreadcrumbItem {
   label: string
@@ -17,6 +18,7 @@ export default function TopNav() {
     { label: "InvestAI", href: "#" },
     { label: "Dashboard", href: "#" },
   ]
+  const criticalAlerts = ALERTS.filter((alert) => alert.status === "critique").length
 
   return (
     <nav className="px-3 sm:px-6 flex items-center justify-between bg-transparent h-full">
@@ -39,6 +41,18 @@ export default function TopNav() {
       </div>
 
       <div className="flex items-center gap-2 sm:gap-4 ml-auto sm:ml-0">
+        <button
+          type="button"
+          className="relative p-1.5 sm:p-2 hover:bg-accent/60 rounded-full transition-colors"
+        >
+          <AlertTriangle className="h-4 w-4 sm:h-5 sm:w-5 text-muted-foreground" />
+          {criticalAlerts > 0 && (
+            <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-rose-500 text-[10px] font-semibold text-white">
+              {criticalAlerts}
+            </span>
+          )}
+        </button>
+
         <button
           type="button"
           className="p-1.5 sm:p-2 hover:bg-accent/60 rounded-full transition-colors"
@@ -70,4 +84,3 @@ export default function TopNav() {
     </nav>
   )
 }
-

--- a/lib/portfolio-context.tsx
+++ b/lib/portfolio-context.tsx
@@ -6,6 +6,7 @@ import {
   ALLOCATION_ACTUAL as DEFAULT_ALLOCATION_ACTUAL,
   ALLOCATION_TARGETS as DEFAULT_ALLOCATION_TARGETS,
   ASSET_BREAKDOWN as DEFAULT_ASSET_BREAKDOWN,
+  ALERTS as DEFAULT_ALERTS,
   BUDGETS as DEFAULT_BUDGETS,
   CASHFLOW_FORECAST as DEFAULT_CASHFLOW_FORECAST,
   DIVERSIFICATION_BREAKDOWN as DEFAULT_DIVERSIFICATION_BREAKDOWN,
@@ -30,6 +31,7 @@ import {
   type StockAction,
   type BudgetCategory,
   type CashflowForecastPoint,
+  type PortfolioAlert,
   type AlertThreshold,
   type PlanningScenario,
   type DiversificationBreakdown,
@@ -171,6 +173,7 @@ interface PortfolioContextType {
   liabilityBreakdown: NetWorthBreakdownItem[]
   budgets: BudgetCategory[]
   cashflowForecast: CashflowForecastPoint[]
+  alerts: PortfolioAlert[]
   alertsThresholds: AlertThreshold[]
   planningScenarios: PlanningScenario[]
 
@@ -368,6 +371,7 @@ export function PortfolioProvider({ children }: { children: React.ReactNode }) {
       liabilityBreakdown: DEFAULT_LIABILITY_BREAKDOWN,
       budgets: DEFAULT_BUDGETS,
       cashflowForecast: DEFAULT_CASHFLOW_FORECAST,
+      alerts: DEFAULT_ALERTS,
       alertsThresholds: DEFAULT_ALERTS_THRESHOLDS,
       planningScenarios: DEFAULT_PLANNING_SCENARIOS,
       totalBalance,

--- a/lib/portfolio-data.ts
+++ b/lib/portfolio-data.ts
@@ -133,6 +133,15 @@ export interface AlertThreshold {
   status: "ok" | "warning" | "critical"
 }
 
+export interface PortfolioAlert {
+  id: string
+  title: string
+  description: string
+  category: "prix" | "cash buffer" | "drawdown"
+  status: "actif" | "résolu" | "critique"
+  updatedAt: string
+}
+
 export interface PlanningScenario {
   id: string
   label: string
@@ -606,6 +615,33 @@ export const ALERTS_THRESHOLDS: AlertThreshold[] = [
     threshold: 500,
     current: 460,
     status: "warning",
+  },
+]
+
+export const ALERTS: PortfolioAlert[] = [
+  {
+    id: "price-alert",
+    title: "Prix cible atteint sur NVIDIA",
+    description: "NVDA a franchi le seuil de 15% de hausse sur 30 jours.",
+    category: "prix",
+    status: "actif",
+    updatedAt: "Il y a 10 min",
+  },
+  {
+    id: "cash-buffer",
+    title: "Cash buffer sous le minimum",
+    description: "Le coussin de liquidités est à 18% (objectif 25%).",
+    category: "cash buffer",
+    status: "critique",
+    updatedAt: "Il y a 1 h 12",
+  },
+  {
+    id: "drawdown-alert",
+    title: "Drawdown global stabilisé",
+    description: "Le drawdown repasse sous -6% après rééquilibrage.",
+    category: "drawdown",
+    status: "résolu",
+    updatedAt: "Hier à 17:40",
   },
 ]
 


### PR DESCRIPTION
### Motivation
- Provide a dedicated portfolio alerts panel (price, cash buffer, drawdown) so users can quickly see critical events. 
- Expose structured alert data in the shared portfolio model to allow UI components to consume current alerts. 

### Description
- Added a new component `components/kokonutui/alerts.tsx` that lists alerts with category icons and status badges (`actif`, `résolu`, `critique`).
- Extended `lib/portfolio-data.ts` with a new `PortfolioAlert` interface and a sample `ALERTS` array to represent price / cash buffer / drawdown alerts.
- Updated `lib/portfolio-context.tsx` to expose `alerts` via the `PortfolioProvider` so components can access alerts through `usePortfolio()`.
- Integrated the alerts UI into the dashboard by importing `Alerts` in `components/kokonutui/content.tsx` and added an alerts indicator (badge) to `components/kokonutui/top-nav.tsx`; also fixed an icon import (replaced nonexistent `LineChartDown` with `ArrowDownRight`).

### Testing
- Started the dev server with `pnpm dev` and verified Next.js compiled (fallback fonts warnings only) and the dashboard route returned `200` after fixes, which succeeded.
- Ran a Playwright script to load the running app and captured a screenshot artifact `artifacts/alerts-dashboard.png`, which completed successfully.
- Resolved an import/runtime error during the first build (missing icon) and confirmed the subsequent rebuild and page render succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698695ac8ee8832b9ca5c409b23dd1be)