### PR TITLE
Add debt payoff planning UI plus debt data and context

### DIFF
--- a/components/kokonutui/content.tsx
+++ b/components/kokonutui/content.tsx
@@ -12,6 +12,7 @@ import {
   ClipboardList,
   RefreshCcw,
   Plug,
+  BadgePercent,
 } from "lucide-react"
 import List01 from "./list-01"
 import List02 from "./list-02"
@@ -24,6 +25,7 @@ import NetWorth from "./net-worth"
 import BudgetCashflow from "./budget-cashflow"
 import PlanningScenarios from "./planning-scenarios"
 import Integrations from "./integrations"
+import DebtPlan from "./debt-plan"
 import { PortfolioProvider } from "@/lib/portfolio-context"
 
 export default function Content() {
@@ -100,6 +102,18 @@ export default function Content() {
             </h2>
           </div>
           <Rebalancing className="w-full" />
+        </section>
+
+        <section id="debt-plan" className="space-y-3 scroll-mt-24">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+              <BadgePercent className="w-4 h-4 text-primary" />
+            </div>
+            <h2 className="text-sm font-semibold tracking-tight text-foreground">
+              Plan de désendettement
+            </h2>
+          </div>
+          <DebtPlan className="w-full" />
         </section>
 
         <section id="budget-cashflow" className="space-y-3 scroll-mt-24">

--- a/components/kokonutui/debt-plan.tsx
+++ b/components/kokonutui/debt-plan.tsx
@@ -1,0 +1,171 @@
+"use client"
+
+import { useMemo } from "react"
+import { ArrowDownUp, Flame, Snowflake } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { usePortfolio } from "@/lib/portfolio-context"
+
+interface DebtPlanProps {
+  className?: string
+}
+
+const debtTypeLabels = {
+  "credit-card": "Carte",
+  loan: "Prêt",
+  auto: "Auto",
+  student: "Étudiant",
+}
+
+export default function DebtPlan({ className }: DebtPlanProps) {
+  const { debtItems, debtStrategyComparison, debtInterestProjection } = usePortfolio()
+
+  const sortedDebts = useMemo(
+    () => [...debtItems].sort((a, b) => b.apr - a.apr),
+    [debtItems]
+  )
+
+  const maxInterest = Math.max(...debtInterestProjection.map((point) => point.interest))
+  const formatCurrency = (value: number) =>
+    `$${value.toLocaleString("en-US", { maximumFractionDigits: 0 })}`
+
+  return (
+    <div className={cn("w-full fx-panel", className)}>
+      <div className="p-4 border-b border-border/60">
+        <p className="text-xs text-muted-foreground">Plan de désendettement</p>
+        <h3 className="text-base font-semibold text-foreground">
+          Comparaison snowball vs avalanche et intérêts projetés
+        </h3>
+      </div>
+
+      <div className="grid gap-4 p-4 lg:grid-cols-[1.2fr_1fr]">
+        <div className="space-y-4">
+          <div className="rounded-lg border border-border/60 bg-background/60 p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs font-semibold text-foreground">Stratégies comparées</p>
+                <p className="text-[11px] text-muted-foreground">
+                  Même mensualité, impact différent sur les intérêts.
+                </p>
+              </div>
+              <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                <ArrowDownUp className="h-3.5 w-3.5" />
+                Comparatif
+              </div>
+            </div>
+            <div className="grid gap-3 md:grid-cols-2">
+              {debtStrategyComparison.map((strategy) => (
+                <div
+                  key={strategy.id}
+                  className="rounded-lg border border-border/60 bg-background/80 p-3 space-y-2"
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2 text-xs font-semibold text-foreground">
+                      {strategy.id === "snowball" ? (
+                        <Snowflake className="h-3.5 w-3.5 text-sky-500" />
+                      ) : (
+                        <Flame className="h-3.5 w-3.5 text-rose-500" />
+                      )}
+                      {strategy.label}
+                    </div>
+                    <span className="text-[10px] uppercase text-muted-foreground">
+                      {strategy.payoffMonths} mois
+                    </span>
+                  </div>
+                  <p className="text-[11px] text-muted-foreground">{strategy.description}</p>
+                  <div className="grid gap-2 text-[11px] text-muted-foreground">
+                    <div className="flex items-center justify-between">
+                      <span>Intérêts totaux</span>
+                      <span className="font-semibold text-foreground">
+                        {formatCurrency(strategy.totalInterest)}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span>Mensualité</span>
+                      <span className="font-semibold text-foreground">
+                        {formatCurrency(strategy.monthlyPayment)}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="rounded-md border border-border/60 bg-muted/50 px-2 py-1 text-[10px] text-foreground">
+                    {strategy.highlight}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-border/60 bg-background/60 p-4 space-y-3">
+            <div>
+              <p className="text-xs font-semibold text-foreground">Projection intérêts futurs</p>
+              <p className="text-[11px] text-muted-foreground">
+                Estimation des intérêts sur 6 mois avec plan actuel.
+              </p>
+            </div>
+            <div className="space-y-3">
+              {debtInterestProjection.map((point) => (
+                <div key={point.id} className="space-y-1">
+                  <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+                    <span>{point.label}</span>
+                    <span className="font-medium text-foreground">
+                      {formatCurrency(point.interest)}
+                    </span>
+                  </div>
+                  <div className="relative h-2 w-full rounded-full bg-muted">
+                    <div
+                      className="h-full rounded-full bg-primary/70"
+                      style={{ width: `${(point.interest / maxInterest) * 100}%` }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className="flex items-center justify-between rounded-md border border-border/60 bg-background/80 px-3 py-2 text-[11px]">
+              <span className="text-muted-foreground">Cumul estimé</span>
+              <span className="font-semibold text-foreground">
+                {formatCurrency(debtInterestProjection.at(-1)?.cumulative ?? 0)}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border/60 bg-background/60 p-4 space-y-3">
+          <div>
+            <p className="text-xs font-semibold text-foreground">Priorisation automatique</p>
+            <p className="text-[11px] text-muted-foreground">
+              Classement par taux annuel pour réduire les coûts d&apos;intérêts.
+            </p>
+          </div>
+          <div className="space-y-3">
+            {sortedDebts.map((debt, index) => (
+              <div
+                key={debt.id}
+                className="rounded-lg border border-border/60 bg-background/80 p-3 space-y-2"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-semibold text-foreground">{debt.label}</p>
+                    <p className="text-[11px] text-muted-foreground">{debt.lender}</p>
+                  </div>
+                  <span className="rounded-full border border-border/60 px-2 py-0.5 text-[10px] font-semibold text-foreground">
+                    Priorité {index + 1}
+                  </span>
+                </div>
+                <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
+                  <span className="rounded-full border border-border/60 px-2 py-0.5">
+                    {debtTypeLabels[debt.type]}
+                  </span>
+                  <span>Taux {debt.apr}%</span>
+                  <span>Solde {formatCurrency(debt.balance)}</span>
+                </div>
+                <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+                  <span>Minimum {formatCurrency(debt.minPayment)}</span>
+                  <span>Prochaine échéance {debt.nextPaymentDate}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/portfolio-context.tsx
+++ b/lib/portfolio-context.tsx
@@ -18,6 +18,9 @@ import {
   STOCK_ACTIONS as DEFAULT_STOCK_ACTIONS,
   ALERTS_THRESHOLDS as DEFAULT_ALERTS_THRESHOLDS,
   PLANNING_SCENARIOS as DEFAULT_PLANNING_SCENARIOS,
+  DEBT_ITEMS as DEFAULT_DEBT_ITEMS,
+  DEBT_STRATEGY_COMPARISON as DEFAULT_DEBT_STRATEGY_COMPARISON,
+  DEBT_INTEREST_PROJECTION as DEFAULT_DEBT_INTEREST_PROJECTION,
   type AllocationActual,
   type AllocationTarget,
   type NetWorthBreakdownItem,
@@ -33,6 +36,9 @@ import {
   type AlertThreshold,
   type PlanningScenario,
   type DiversificationBreakdown,
+  type DebtItem,
+  type DebtStrategyComparison,
+  type DebtInterestProjectionPoint,
 } from "./portfolio-data"
 
 // LocalStorage keys for persistence
@@ -173,6 +179,9 @@ interface PortfolioContextType {
   cashflowForecast: CashflowForecastPoint[]
   alertsThresholds: AlertThreshold[]
   planningScenarios: PlanningScenario[]
+  debtItems: DebtItem[]
+  debtStrategyComparison: DebtStrategyComparison[]
+  debtInterestProjection: DebtInterestProjectionPoint[]
 
   // Computed values
   totalBalance: string
@@ -370,6 +379,9 @@ export function PortfolioProvider({ children }: { children: React.ReactNode }) {
       cashflowForecast: DEFAULT_CASHFLOW_FORECAST,
       alertsThresholds: DEFAULT_ALERTS_THRESHOLDS,
       planningScenarios: DEFAULT_PLANNING_SCENARIOS,
+      debtItems: DEFAULT_DEBT_ITEMS,
+      debtStrategyComparison: DEFAULT_DEBT_STRATEGY_COMPARISON,
+      debtInterestProjection: DEFAULT_DEBT_INTEREST_PROJECTION,
       totalBalance,
       lastSaved,
     }),

--- a/lib/portfolio-data.ts
+++ b/lib/portfolio-data.ts
@@ -142,6 +142,34 @@ export interface PlanningScenario {
   incomeDelta: number
 }
 
+export interface DebtItem {
+  id: string
+  label: string
+  lender: string
+  balance: number
+  apr: number
+  minPayment: number
+  nextPaymentDate: string
+  type: "credit-card" | "loan" | "auto" | "student"
+}
+
+export interface DebtStrategyComparison {
+  id: string
+  label: string
+  description: string
+  totalInterest: number
+  payoffMonths: number
+  monthlyPayment: number
+  highlight: string
+}
+
+export interface DebtInterestProjectionPoint {
+  id: string
+  label: string
+  interest: number
+  cumulative: number
+}
+
 export const ACCOUNTS: AccountItem[] = [
   {
     id: "1",
@@ -641,6 +669,119 @@ export const PLANNING_SCENARIOS: PlanningScenario[] = [
     rateDelta: 0,
     marketShock: 0,
     incomeDelta: -0.25,
+  },
+]
+
+export const DEBT_ITEMS: DebtItem[] = [
+  {
+    id: "debt-cc-1",
+    label: "Carte premium",
+    lender: "Banque Horizon",
+    balance: 4620,
+    apr: 19.9,
+    minPayment: 140,
+    nextPaymentDate: "15 Oct 2024",
+    type: "credit-card",
+  },
+  {
+    id: "debt-cc-2",
+    label: "Carte cashback",
+    lender: "Union Finance",
+    balance: 1850,
+    apr: 16.2,
+    minPayment: 85,
+    nextPaymentDate: "22 Oct 2024",
+    type: "credit-card",
+  },
+  {
+    id: "debt-auto-1",
+    label: "Prêt auto",
+    lender: "AutoLease",
+    balance: 9200,
+    apr: 6.4,
+    minPayment: 260,
+    nextPaymentDate: "03 Oct 2024",
+    type: "auto",
+  },
+  {
+    id: "debt-loan-1",
+    label: "Prêt personnel",
+    lender: "Nova Crédit",
+    balance: 5400,
+    apr: 11.5,
+    minPayment: 175,
+    nextPaymentDate: "28 Sep 2024",
+    type: "loan",
+  },
+  {
+    id: "debt-student-1",
+    label: "Prêt étudiant",
+    lender: "Campus Plus",
+    balance: 12800,
+    apr: 4.2,
+    minPayment: 210,
+    nextPaymentDate: "07 Oct 2024",
+    type: "student",
+  },
+]
+
+export const DEBT_STRATEGY_COMPARISON: DebtStrategyComparison[] = [
+  {
+    id: "snowball",
+    label: "Snowball",
+    description: "Priorité aux petites dettes pour maximiser l'élan.",
+    totalInterest: 4860,
+    payoffMonths: 31,
+    monthlyPayment: 980,
+    highlight: "Motivation rapide (+2 dettes clôturées)",
+  },
+  {
+    id: "avalanche",
+    label: "Avalanche",
+    description: "Priorité aux taux élevés pour réduire les intérêts.",
+    totalInterest: 3820,
+    payoffMonths: 28,
+    monthlyPayment: 980,
+    highlight: "Économie d'intérêts estimée à 1 040 $",
+  },
+]
+
+export const DEBT_INTEREST_PROJECTION: DebtInterestProjectionPoint[] = [
+  {
+    id: "oct",
+    label: "Oct",
+    interest: 312,
+    cumulative: 312,
+  },
+  {
+    id: "nov",
+    label: "Nov",
+    interest: 298,
+    cumulative: 610,
+  },
+  {
+    id: "dec",
+    label: "Déc",
+    interest: 285,
+    cumulative: 895,
+  },
+  {
+    id: "jan",
+    label: "Jan",
+    interest: 271,
+    cumulative: 1166,
+  },
+  {
+    id: "feb",
+    label: "Fév",
+    interest: 258,
+    cumulative: 1424,
+  },
+  {
+    id: "mar",
+    label: "Mar",
+    interest: 244,
+    cumulative: 1668,
   },
 ]
 


### PR DESCRIPTION
### Motivation
- Provide a dedicated debt payoff planning section to help compare `snowball` vs `avalanche`, show projected future interest, and automatically prioritize debts by APR.
- Make detailed debt fixtures available to the UI by adding structured debt data and exposing it through the portfolio context.

### Description
- Added new types and fixtures in `lib/portfolio-data.ts`: `DebtItem`, `DebtStrategyComparison`, `DebtInterestProjectionPoint`, plus `DEBT_ITEMS`, `DEBT_STRATEGY_COMPARISON`, and `DEBT_INTEREST_PROJECTION` sample data.
- Exposed the new debt data via the portfolio provider by adding `debtItems`, `debtStrategyComparison`, and `debtInterestProjection` to the `PortfolioContext` in `lib/portfolio-context.tsx`.
- Implemented a new UI component `components/kokonutui/debt-plan.tsx` to render strategy comparison, interest projection, and automatic APR-based prioritization.
- Integrated the new component into the dashboard by importing and adding the section in `components/kokonutui/content.tsx`.

### Testing
- Launched the development server with `pnpm dev` and confirmed Next.js compiled successfully and served pages (server became ready).
- Ran an automated Playwright script that navigated to `http://localhost:3000`, scrolled to the `#debt-plan` section, and saved a screenshot at `artifacts/debt-plan.png`, which completed successfully.
- Observed successful page responses including `GET /dashboard 200` and completed compilation despite Google Fonts fallbacks due to network fetch issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698695b077a0832b90c73cbd62ccd252)