### PR TITLE
Expose diversificationBreakdown in portfolio summary

### DIFF
--- a/lib/portfolio-data.ts
+++ b/lib/portfolio-data.ts
@@ -671,6 +671,7 @@ export function getPortfolioSummary() {
     accounts: ACCOUNTS,
     transactions: TRANSACTIONS,
     financialGoals: FINANCIAL_GOALS,
+    diversificationBreakdown: DIVERSIFICATION_BREAKDOWN,
     summary: {
       totalSavings,
       totalInvestments,


### PR DESCRIPTION
### Motivation
- Make the existing diversification data available to downstream consumers (AI advisor and other listeners) by including it in the portfolio summary payload.

### Description
- Add `diversificationBreakdown: DIVERSIFICATION_BREAKDOWN` to the object returned by `getPortfolioSummary()` in `lib/portfolio-data.ts` so callers can access the rebalancing actions and diversification analysis.

### Testing
- No automated tests were run for this small change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698695eeb85c832b95ff837740a2f1ae)