### PR TITLE
Add tax optimization panel and data

### DIFF
--- a/components/kokonutui/content.tsx
+++ b/components/kokonutui/content.tsx
@@ -12,6 +12,7 @@ import {
   ClipboardList,
   RefreshCcw,
   Plug,
+  Percent,
 } from "lucide-react"
 import List01 from "./list-01"
 import List02 from "./list-02"
@@ -24,6 +25,7 @@ import NetWorth from "./net-worth"
 import BudgetCashflow from "./budget-cashflow"
 import PlanningScenarios from "./planning-scenarios"
 import Integrations from "./integrations"
+import TaxOptimization from "./tax-optimization"
 import { PortfolioProvider } from "@/lib/portfolio-context"
 
 export default function Content() {
@@ -112,6 +114,18 @@ export default function Content() {
             </h2>
           </div>
           <BudgetCashflow className="w-full" />
+        </section>
+
+        <section id="tax-optimization" className="space-y-3 scroll-mt-24">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+              <Percent className="w-4 h-4 text-primary" />
+            </div>
+            <h2 className="text-sm font-semibold tracking-tight text-foreground">
+              Optimisation fiscale
+            </h2>
+          </div>
+          <TaxOptimization className="w-full" />
         </section>
 
         <section id="planning-scenarios" className="space-y-3 scroll-mt-24">

--- a/components/kokonutui/tax-optimization.tsx
+++ b/components/kokonutui/tax-optimization.tsx
@@ -1,0 +1,139 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import { usePortfolio } from "@/lib/portfolio-context"
+
+interface TaxOptimizationProps {
+  className?: string
+}
+
+const formatCurrency = (value: number) =>
+  value.toLocaleString("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+    maximumFractionDigits: 0,
+  })
+
+const formatPercent = (value: number) => `${value > 0 ? "+" : ""}${value.toFixed(1)}%`
+
+export default function TaxOptimization({ className }: TaxOptimizationProps) {
+  const { taxOptimization } = usePortfolio()
+  const { unrealizedGains, realizedGains, dividendTaxEstimate, peaAdvice, lifeInsuranceAdvice } =
+    taxOptimization
+
+  const trendClass = (value: number) => (value >= 0 ? "text-emerald-600" : "text-rose-600")
+
+  return (
+    <div className={cn("w-full fx-panel", className)}>
+      <div className="border-b border-border/60 p-4">
+        <p className="text-xs text-muted-foreground">Optimisation fiscale</p>
+        <h3 className="text-base font-semibold text-foreground">
+          Plus/moins-values &amp; impacts dividendes
+        </h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Synthèse des gains latents, réalisés et conseils fiscaux associés.
+        </p>
+      </div>
+
+      <div className="grid gap-4 border-b border-border/60 p-4 md:grid-cols-2">
+        {[{ title: "Plus-values latentes", data: unrealizedGains }].map((item) => (
+          <div key={item.title} className="rounded-lg border border-border/60 bg-background/60 p-4">
+            <p className="text-xs text-muted-foreground">{item.title}</p>
+            <div className="mt-2 flex items-baseline justify-between">
+              <span className="text-xl font-semibold text-foreground">
+                {formatCurrency(item.data.amount)}
+              </span>
+              <span className={cn("text-xs font-semibold", trendClass(item.data.change))}>
+                {formatPercent(item.data.change)}
+              </span>
+            </div>
+            <p className="mt-2 text-[11px] text-muted-foreground">{item.data.note}</p>
+          </div>
+        ))}
+
+        <div className="rounded-lg border border-border/60 bg-background/60 p-4">
+          <p className="text-xs text-muted-foreground">Plus-values réalisées</p>
+          <div className="mt-2 flex items-baseline justify-between">
+            <span className="text-xl font-semibold text-foreground">
+              {formatCurrency(realizedGains.amount)}
+            </span>
+            <span className={cn("text-xs font-semibold", trendClass(realizedGains.change))}>
+              {formatPercent(realizedGains.change)}
+            </span>
+          </div>
+          <p className="mt-2 text-[11px] text-muted-foreground">{realizedGains.note}</p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 border-b border-border/60 p-4 lg:grid-cols-[1.1fr_1fr]">
+        <div className="rounded-lg border border-border/60 bg-background/60 p-4">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-xs font-semibold text-foreground">Estimation impôts dividendes</p>
+              <p className="mt-1 text-[11px] text-muted-foreground">{dividendTaxEstimate.note}</p>
+            </div>
+            <div className="rounded-full border border-border/60 bg-background/80 px-2 py-1 text-[10px] text-muted-foreground">
+              PFU {formatPercent(dividendTaxEstimate.flatTaxRate * 100)}
+            </div>
+          </div>
+          <div className="mt-4 grid gap-3 text-xs text-muted-foreground">
+            <div className="flex items-center justify-between">
+              <span>Dividendes bruts</span>
+              <span className="font-medium text-foreground">
+                {formatCurrency(dividendTaxEstimate.grossDividends)}
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span>Assiette taxable</span>
+              <span className="font-medium text-foreground">
+                {formatCurrency(dividendTaxEstimate.taxableBase)}
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span>Impôt estimé</span>
+              <span className="font-medium text-foreground">
+                {formatCurrency(dividendTaxEstimate.estimatedTax)}
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span>Mode de paiement</span>
+              <span className="text-[11px] text-muted-foreground">
+                {dividendTaxEstimate.paymentSchedule}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border/60 bg-background/60 p-4">
+          <p className="text-xs font-semibold text-foreground">Conseils ciblés</p>
+          <div className="mt-3 grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                PEA
+              </p>
+              <ul className="space-y-2 text-[11px] text-muted-foreground">
+                {peaAdvice.map((item) => (
+                  <li key={item} className="rounded-md border border-border/60 bg-background/80 p-2">
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="space-y-2">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                Assurance-vie
+              </p>
+              <ul className="space-y-2 text-[11px] text-muted-foreground">
+                {lifeInsuranceAdvice.map((item) => (
+                  <li key={item} className="rounded-md border border-border/60 bg-background/80 p-2">
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/portfolio-context.tsx
+++ b/lib/portfolio-context.tsx
@@ -18,6 +18,7 @@ import {
   STOCK_ACTIONS as DEFAULT_STOCK_ACTIONS,
   ALERTS_THRESHOLDS as DEFAULT_ALERTS_THRESHOLDS,
   PLANNING_SCENARIOS as DEFAULT_PLANNING_SCENARIOS,
+  TAX_OPTIMIZATION as DEFAULT_TAX_OPTIMIZATION,
   type AllocationActual,
   type AllocationTarget,
   type NetWorthBreakdownItem,
@@ -33,6 +34,7 @@ import {
   type AlertThreshold,
   type PlanningScenario,
   type DiversificationBreakdown,
+  type TaxOptimizationData,
 } from "./portfolio-data"
 
 // LocalStorage keys for persistence
@@ -173,6 +175,7 @@ interface PortfolioContextType {
   cashflowForecast: CashflowForecastPoint[]
   alertsThresholds: AlertThreshold[]
   planningScenarios: PlanningScenario[]
+  taxOptimization: TaxOptimizationData
 
   // Computed values
   totalBalance: string
@@ -370,6 +373,7 @@ export function PortfolioProvider({ children }: { children: React.ReactNode }) {
       cashflowForecast: DEFAULT_CASHFLOW_FORECAST,
       alertsThresholds: DEFAULT_ALERTS_THRESHOLDS,
       planningScenarios: DEFAULT_PLANNING_SCENARIOS,
+      taxOptimization: DEFAULT_TAX_OPTIMIZATION,
       totalBalance,
       lastSaved,
     }),

--- a/lib/portfolio-data.ts
+++ b/lib/portfolio-data.ts
@@ -142,6 +142,29 @@ export interface PlanningScenario {
   incomeDelta: number
 }
 
+export interface TaxGainSummary {
+  amount: number
+  change: number
+  note: string
+}
+
+export interface DividendTaxEstimate {
+  grossDividends: number
+  taxableBase: number
+  flatTaxRate: number
+  estimatedTax: number
+  paymentSchedule: string
+  note: string
+}
+
+export interface TaxOptimizationData {
+  unrealizedGains: TaxGainSummary
+  realizedGains: TaxGainSummary
+  dividendTaxEstimate: DividendTaxEstimate
+  peaAdvice: string[]
+  lifeInsuranceAdvice: string[]
+}
+
 export const ACCOUNTS: AccountItem[] = [
   {
     id: "1",
@@ -643,6 +666,35 @@ export const PLANNING_SCENARIOS: PlanningScenario[] = [
     incomeDelta: -0.25,
   },
 ]
+
+export const TAX_OPTIMIZATION: TaxOptimizationData = {
+  unrealizedGains: {
+    amount: 18450,
+    change: 6.4,
+    note: "Latent sur ETF monde & actions tech",
+  },
+  realizedGains: {
+    amount: 3420,
+    change: -1.8,
+    note: "Prises de bénéfices récentes",
+  },
+  dividendTaxEstimate: {
+    grossDividends: 1280,
+    taxableBase: 1152,
+    flatTaxRate: 0.3,
+    estimatedTax: 346,
+    paymentSchedule: "Acompte mensuel ou prélèvement PFU",
+    note: "Inclut 12,8% IR + 17,2% prélèvements sociaux",
+  },
+  peaAdvice: [
+    "Prioriser les arbitrages gagnants dans le PEA pour bénéficier de l'exonération après 5 ans.",
+    "Conserver une poche liquidité pour saisir les corrections sans sortir du PEA.",
+  ],
+  lifeInsuranceAdvice: [
+    "Utiliser les rachats partiels programmés pour lisser la fiscalité annuelle.",
+    "Favoriser les versements sur les fonds euros en période de volatilité.",
+  ],
+}
 
 export const TOTAL_BALANCE = "$26,540.25"
 


### PR DESCRIPTION
### Motivation
- Provide a dedicated tax-optimization UI that surfaces unrealized/realized gains, dividend tax estimates and targeted advice for PEA and assurance-vie using existing portfolio data. 

### Description
- Add new data types `TaxGainSummary`, `DividendTaxEstimate`, and `TaxOptimizationData` and a default `TAX_OPTIMIZATION` export in `lib/portfolio-data.ts` to model fiscal insights. 
- Expose the tax optimization defaults through the portfolio context by wiring `DEFAULT_TAX_OPTIMIZATION` into `lib/portfolio-context.tsx` and adding `taxOptimization` to the context type. 
- Implement a new dashboard panel component `components/kokonutui/tax-optimization.tsx` that displays plus/moins-values, a dividend tax breakdown and PEA/assurance-vie advice. 
- Insert the `TaxOptimization` panel into `components/kokonutui/content.tsx` with an icon so the panel appears in the main dashboard flow. 

### Testing
- Launched the dev server with `pnpm dev`, which compiled successfully and served pages (Next reported readiness and served `/dashboard` with `200`).
- Captured a visual verification screenshot via a Playwright script which saved the page snapshot to `artifacts/tax-optimization.png` and confirmed the new panel renders; compilation logged Google Fonts fetch warnings but fell back to fonts and continued.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698695fb4700832b8048f7f1dc6f27bb)