### PR TITLE
Replace stacked dashboard sections with tabbed layout

### DIFF
--- a/components/kokonutui/content.tsx
+++ b/components/kokonutui/content.tsx
@@ -27,153 +27,171 @@ import PlanningScenarios from "./planning-scenarios"
 import Integrations from "./integrations"
 import Alerts from "./alerts"
 import { PortfolioProvider } from "@/lib/portfolio-context"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 export default function Content() {
   return (
     <PortfolioProvider>
-      <div className="space-y-8">
-        <section id="ai-advisor" className="space-y-3 scroll-mt-24">
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
-              <Bot className="w-4 h-4 text-primary" />
-            </div>
-            <h2 className="text-sm font-semibold tracking-tight text-foreground">
-              AI Investment Advisor
-            </h2>
-          </div>
-          <AIAdvisor className="w-full" />
-        </section>
+      <Tabs defaultValue="overview" className="space-y-6">
+        <TabsList className="flex h-auto flex-wrap justify-start gap-2 bg-transparent p-0">
+          <TabsTrigger value="overview">Vue d’ensemble</TabsTrigger>
+          <TabsTrigger value="portfolio">Portefeuille</TabsTrigger>
+          <TabsTrigger value="budget">Budget &amp; Planification</TabsTrigger>
+          <TabsTrigger value="integrations">Intégrations</TabsTrigger>
+        </TabsList>
 
-        <section id="alerts" className="space-y-3 scroll-mt-24">
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
-              <AlertTriangle className="w-4 h-4 text-primary" />
-            </div>
-            <h2 className="text-sm font-semibold tracking-tight text-foreground">Alertes clés</h2>
-          </div>
-          <Alerts className="w-full" />
-        </section>
-
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <section id="accounts" className="space-y-3 scroll-mt-24">
+        <TabsContent value="overview" className="space-y-8">
+          <section id="ai-advisor" className="space-y-3 scroll-mt-24">
             <div className="flex items-center gap-3">
               <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
-                <Wallet className="w-4 h-4 text-primary" />
-              </div>
-              <h2 className="text-sm font-semibold tracking-tight text-foreground">Accounts</h2>
-            </div>
-            <List01 className="h-full w-full" />
-          </section>
-
-          <section id="transactions" className="space-y-3 scroll-mt-24">
-            <div className="flex items-center gap-3">
-              <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
-                <CreditCard className="w-4 h-4 text-primary" />
+                <Bot className="w-4 h-4 text-primary" />
               </div>
               <h2 className="text-sm font-semibold tracking-tight text-foreground">
-                Recent Transactions
+                AI Investment Advisor
               </h2>
             </div>
-            <List02 className="h-full w-full" />
+            <AIAdvisor className="w-full" />
           </section>
 
-          <section id="performance-allocation" className="space-y-3 scroll-mt-24">
+          <section id="alerts" className="space-y-3 scroll-mt-24">
             <div className="flex items-center gap-3">
               <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
-                <PieChart className="w-4 h-4 text-primary" />
+                <AlertTriangle className="w-4 h-4 text-primary" />
               </div>
               <h2 className="text-sm font-semibold tracking-tight text-foreground">
-                Performance & Allocation
+                Alertes clés
               </h2>
             </div>
-            <PerformanceAllocation className="h-full w-full" />
+            <Alerts className="w-full" />
           </section>
-        </div>
 
-        <section id="stock-actions" className="space-y-3 scroll-mt-24">
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
-              <TrendingUp className="w-4 h-4 text-primary" />
+          <section id="net-worth" className="space-y-3 scroll-mt-24">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+                <LineChart className="w-4 h-4 text-primary" />
+              </div>
+              <h2 className="text-sm font-semibold tracking-tight text-foreground">
+                Net Worth
+              </h2>
             </div>
-            <h2 className="text-sm font-semibold tracking-tight text-foreground">
-              Stock Market Actions
-            </h2>
-          </div>
-          <List04 className="h-full w-full" />
-        </section>
+            <NetWorth className="h-full w-full" />
+          </section>
+        </TabsContent>
 
-        <section id="rebalancing" className="space-y-3 scroll-mt-24">
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
-              <RefreshCcw className="w-4 h-4 text-primary" />
-            </div>
-            <h2 className="text-sm font-semibold tracking-tight text-foreground">
-              Rééquilibrage
-            </h2>
-          </div>
-          <Rebalancing className="w-full" />
-        </section>
+        <TabsContent value="portfolio" className="space-y-8">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <section id="accounts" className="space-y-3 scroll-mt-24">
+              <div className="flex items-center gap-3">
+                <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+                  <Wallet className="w-4 h-4 text-primary" />
+                </div>
+                <h2 className="text-sm font-semibold tracking-tight text-foreground">Accounts</h2>
+              </div>
+              <List01 className="h-full w-full" />
+            </section>
 
-        <section id="budget-cashflow" className="space-y-3 scroll-mt-24">
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
-              <PiggyBank className="w-4 h-4 text-primary" />
-            </div>
-            <h2 className="text-sm font-semibold tracking-tight text-foreground">
-              Budget & Cashflow
-            </h2>
-          </div>
-          <BudgetCashflow className="w-full" />
-        </section>
+            <section id="transactions" className="space-y-3 scroll-mt-24">
+              <div className="flex items-center gap-3">
+                <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+                  <CreditCard className="w-4 h-4 text-primary" />
+                </div>
+                <h2 className="text-sm font-semibold tracking-tight text-foreground">
+                  Recent Transactions
+                </h2>
+              </div>
+              <List02 className="h-full w-full" />
+            </section>
 
-        <section id="planning-scenarios" className="space-y-3 scroll-mt-24">
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
-              <ClipboardList className="w-4 h-4 text-primary" />
-            </div>
-            <h2 className="text-sm font-semibold tracking-tight text-foreground">
-              Scénarios de planification
-            </h2>
+            <section id="performance-allocation" className="space-y-3 scroll-mt-24">
+              <div className="flex items-center gap-3">
+                <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+                  <PieChart className="w-4 h-4 text-primary" />
+                </div>
+                <h2 className="text-sm font-semibold tracking-tight text-foreground">
+                  Performance & Allocation
+                </h2>
+              </div>
+              <PerformanceAllocation className="h-full w-full" />
+            </section>
           </div>
-          <PlanningScenarios className="w-full" />
-        </section>
 
-        <section id="integrations" className="space-y-3 scroll-mt-24">
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
-              <Plug className="w-4 h-4 text-primary" />
+          <section id="stock-actions" className="space-y-3 scroll-mt-24">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+                <TrendingUp className="w-4 h-4 text-primary" />
+              </div>
+              <h2 className="text-sm font-semibold tracking-tight text-foreground">
+                Stock Market Actions
+              </h2>
             </div>
-            <h2 className="text-sm font-semibold tracking-tight text-foreground">
-              Intégrations & synchronisation
-            </h2>
-          </div>
-          <Integrations />
-        </section>
+            <List04 className="h-full w-full" />
+          </section>
 
-        <section id="net-worth" className="space-y-3 scroll-mt-24">
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
-              <LineChart className="w-4 h-4 text-primary" />
+          <section id="rebalancing" className="space-y-3 scroll-mt-24">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+                <RefreshCcw className="w-4 h-4 text-primary" />
+              </div>
+              <h2 className="text-sm font-semibold tracking-tight text-foreground">
+                Rééquilibrage
+              </h2>
             </div>
-            <h2 className="text-sm font-semibold tracking-tight text-foreground">
-              Net Worth
-            </h2>
-          </div>
-          <NetWorth className="h-full w-full" />
-        </section>
+            <Rebalancing className="w-full" />
+          </section>
+        </TabsContent>
 
-        <section id="goals" className="space-y-3 scroll-mt-24">
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
-              <Target className="w-4 h-4 text-primary" />
+        <TabsContent value="budget" className="space-y-8">
+          <section id="budget-cashflow" className="space-y-3 scroll-mt-24">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+                <PiggyBank className="w-4 h-4 text-primary" />
+              </div>
+              <h2 className="text-sm font-semibold tracking-tight text-foreground">
+                Budget & Cashflow
+              </h2>
             </div>
-            <h2 className="text-sm font-semibold tracking-tight text-foreground">
-              Financial Goals
-            </h2>
-          </div>
-          <List03 />
-        </section>
-      </div>
+            <BudgetCashflow className="w-full" />
+          </section>
+
+          <section id="planning-scenarios" className="space-y-3 scroll-mt-24">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+                <ClipboardList className="w-4 h-4 text-primary" />
+              </div>
+              <h2 className="text-sm font-semibold tracking-tight text-foreground">
+                Scénarios de planification
+              </h2>
+            </div>
+            <PlanningScenarios className="w-full" />
+          </section>
+
+          <section id="goals" className="space-y-3 scroll-mt-24">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+                <Target className="w-4 h-4 text-primary" />
+              </div>
+              <h2 className="text-sm font-semibold tracking-tight text-foreground">
+                Financial Goals
+              </h2>
+            </div>
+            <List03 />
+          </section>
+        </TabsContent>
+
+        <TabsContent value="integrations" className="space-y-8">
+          <section id="integrations" className="space-y-3 scroll-mt-24">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
+                <Plug className="w-4 h-4 text-primary" />
+              </div>
+              <h2 className="text-sm font-semibold tracking-tight text-foreground">
+                Intégrations & synchronisation
+              </h2>
+            </div>
+            <Integrations />
+          </section>
+        </TabsContent>
+      </Tabs>
     </PortfolioProvider>
   )
 }


### PR DESCRIPTION
### Motivation
- Convert the linear stacked sections into a tabbed UI to improve discoverability and group related functionality into cohesive panels.
- Group content into four logical tabs: Overview, Portfolio, Budget & Planning, and Integrations while keeping in-page anchors functional.

### Description
- Import `Tabs`, `TabsList`, `TabsTrigger`, and `TabsContent` from `components/ui/tabs` and replace the top-level stacked `div` with a `Tabs` root using `defaultValue="overview"`.
- Add a `TabsList` with four `TabsTrigger` entries and move existing sections into corresponding `TabsContent` panels (Overview: AI Advisor, Alerts, Net Worth; Portfolio: Accounts, Recent Transactions, Performance & Allocation, Stock Market Actions, Rebalancing; Budget & Planning: Budget & Cashflow, Planning Scenarios, Financial Goals; Integrations: Integrations & synchronization).
- Preserve existing section `id` attributes for anchors and keep the `PortfolioProvider` wrapper and original grid/layout for the portfolio panel.
- Adjust spacing and classNames minimally to fit the tab panels and reuse all existing child components unchanged.

### Testing
- Started the Next.js dev server (`pnpm next dev`) and confirmed the app compiled and became ready, which succeeded despite Google Fonts fetch warnings that fell back to local fonts.
- Ran a Playwright script to load `http://127.0.0.1:3000` and capture a full-page screenshot (`artifacts/tabs-overview.png`), which completed successfully and verified the tabs render.
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69872c5d6c00832b983e54b5c8615118)