### PR TITLE
Enable horizontal scroll for TabsList on mobile

### DIFF
--- a/components/kokonutui/content.tsx
+++ b/components/kokonutui/content.tsx
@@ -33,7 +33,7 @@ export default function Content() {
   return (
     <PortfolioProvider>
       <Tabs defaultValue="overview" className="space-y-6">
-        <TabsList className="flex h-auto flex-wrap justify-start gap-2 bg-transparent p-0">
+        <TabsList className="flex h-auto flex-nowrap justify-start gap-2 overflow-x-auto whitespace-nowrap bg-transparent p-0">
           <TabsTrigger value="overview">Vue d’ensemble</TabsTrigger>
           <TabsTrigger value="portfolio">Portefeuille</TabsTrigger>
           <TabsTrigger value="budget">Budget &amp; Planification</TabsTrigger>


### PR DESCRIPTION
### Motivation
- Keep the top tabs compact on small screens by enabling horizontal scrolling so tab triggers don’t wrap into multiple rows.

### Description
- Update `TabsList` in `components/kokonutui/content.tsx` to add Tailwind classes `overflow-x-auto`, `whitespace-nowrap`, and `flex-nowrap` so the tabs form a single, horizontally scrollable row.

### Testing
- Ran an automated Playwright script that loaded the app at a mobile viewport and captured a screenshot of the tabs to verify horizontal scrolling; the script completed successfully and produced the artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69872f3cb3f8832bb60dca53240636f0)