### PR TITLE
Fix sidebar navigation for dashboard tabs

### DIFF
--- a/components/kokonutui/content.tsx
+++ b/components/kokonutui/content.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useEffect, useMemo, useState } from "react"
 import {
   Target,
   CreditCard,
@@ -30,9 +31,52 @@ import { PortfolioProvider } from "@/lib/portfolio-context"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 export default function Content() {
+  const sectionToTab = useMemo(
+    () => ({
+      "ai-advisor": "overview",
+      alerts: "overview",
+      "net-worth": "overview",
+      accounts: "portfolio",
+      transactions: "portfolio",
+      "performance-allocation": "portfolio",
+      "stock-actions": "portfolio",
+      rebalancing: "portfolio",
+      "budget-cashflow": "budget",
+      "planning-scenarios": "budget",
+      goals: "budget",
+      integrations: "integrations",
+    }),
+    []
+  )
+
+  const [tabValue, setTabValue] = useState("overview")
+
+  useEffect(() => {
+    const syncTabWithHash = () => {
+      const hash = window.location.hash.replace("#", "")
+      if (!hash) {
+        return
+      }
+      const nextTab = sectionToTab[hash as keyof typeof sectionToTab]
+      if (nextTab) {
+        setTabValue(nextTab)
+        requestAnimationFrame(() => {
+          const target = document.getElementById(hash)
+          target?.scrollIntoView({ behavior: "smooth", block: "start" })
+        })
+      }
+    }
+
+    syncTabWithHash()
+    window.addEventListener("hashchange", syncTabWithHash)
+    return () => {
+      window.removeEventListener("hashchange", syncTabWithHash)
+    }
+  }, [sectionToTab])
+
   return (
     <PortfolioProvider>
-      <Tabs defaultValue="overview" className="space-y-6">
+      <Tabs value={tabValue} onValueChange={setTabValue} className="space-y-6">
         <TabsList className="flex h-auto flex-nowrap justify-start gap-2 overflow-x-auto whitespace-nowrap bg-transparent p-0">
           <TabsTrigger value="overview">Vue d’ensemble</TabsTrigger>
           <TabsTrigger value="portfolio">Portefeuille</TabsTrigger>

--- a/components/kokonutui/sidebar.tsx
+++ b/components/kokonutui/sidebar.tsx
@@ -85,10 +85,10 @@ export default function Sidebar() {
                   <NavItem href="/dashboard" icon={Home}>
                     Dashboard
                   </NavItem>
-                  <NavItem href="#ai-advisor" icon={Bot}>
+                  <NavItem href="/dashboard#ai-advisor" icon={Bot}>
                     AI Advisor
                   </NavItem>
-                  <NavItem href="#accounts" icon={BarChart2}>
+                  <NavItem href="/dashboard#accounts" icon={BarChart2}>
                     Accounts Overview
                   </NavItem>
                 </div>
@@ -99,13 +99,13 @@ export default function Sidebar() {
                   Portfolio
                 </div>
                 <div className="space-y-1">
-                  <NavItem href="#accounts" icon={Wallet}>
+                  <NavItem href="/dashboard#accounts" icon={Wallet}>
                     Accounts
                   </NavItem>
-                  <NavItem href="#stock-actions" icon={TrendingUp}>
+                  <NavItem href="/dashboard#stock-actions" icon={TrendingUp}>
                     Stock Actions
                   </NavItem>
-                  <NavItem href="#transactions" icon={Receipt}>
+                  <NavItem href="/dashboard#transactions" icon={Receipt}>
                     Transactions
                   </NavItem>
                 </div>
@@ -116,16 +116,16 @@ export default function Sidebar() {
                   Planning
                 </div>
                 <div className="space-y-1">
-                  <NavItem href="#goals" icon={Target}>
+                  <NavItem href="/dashboard#goals" icon={Target}>
                     Goals
                   </NavItem>
-                  <NavItem href="#goals" icon={PiggyBank}>
+                  <NavItem href="/dashboard#goals" icon={PiggyBank}>
                     Savings
                   </NavItem>
-                  <NavItem href="#transactions" icon={CreditCard}>
+                  <NavItem href="/dashboard#transactions" icon={CreditCard}>
                     Budgets
                   </NavItem>
-                  <NavItem href="#integrations" icon={Plug}>
+                  <NavItem href="/dashboard#integrations" icon={Plug}>
                     Intégrations
                   </NavItem>
                 </div>


### PR DESCRIPTION
### Motivation
- Sidebar anchor links stopped redirecting to the right dashboard sections and did not open the corresponding tab, so navigation from other pages was broken.
- The goal is to make sidebar links reliably open the correct tab and scroll to the target section on the dashboard.

### Description
- Added a section->tab mapping and controlled tab state with `useState` (`tabValue`) and `onValueChange` so tabs can be switched programmatically in `components/kokonutui/content.tsx`.
- Implemented a `useEffect` that watches `window.location.hash`, maps a hash to the matching tab, sets the tab, and smoothly scrolls to the target element.
- Updated sidebar links in `components/kokonutui/sidebar.tsx` to point to `/dashboard#<section>` anchors so clicking from any route navigates to the dashboard anchors.
- Imported required React hooks (`useEffect`, `useMemo`, `useState`) and kept previous behavior for mobile menu handling.

### Testing
- Started the dev server with `pnpm dev` and confirmed `/dashboard` compiled and served successfully (GET /dashboard 200). (succeeded)
- Executed a Playwright script that navigated to `http://127.0.0.1:3000/dashboard`, clicked the "Portfolio" and then "Budget & Planification" tabs, and saved a screenshot at `artifacts/sidebar-tabs.png`. (succeeded)
- Noted transient font download warnings during compilation but they did not block the functional check. (non-blocking)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987373546a8832b836bb51d4a567305)