### PR TITLE
Fix sidebar hash navigation on repeated clicks

### DIFF
--- a/components/kokonutui/sidebar.tsx
+++ b/components/kokonutui/sidebar.tsx
@@ -18,13 +18,35 @@ import {
   Plug,
 } from "lucide-react"
 import Link from "next/link"
+import { usePathname } from "next/navigation"
 import { useState } from "react"
 
 export default function Sidebar() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+  const pathname = usePathname()
 
   function handleNavigation() {
     setIsMobileMenuOpen(false)
+  }
+
+  function handleHashClick(event: React.MouseEvent<HTMLAnchorElement>, href: string) {
+    if (!href.includes("#")) {
+      handleNavigation()
+      return
+    }
+
+    const [targetPath, hash] = href.split("#")
+    if (targetPath && targetPath !== pathname) {
+      handleNavigation()
+      return
+    }
+
+    event.preventDefault()
+    handleNavigation()
+
+    if (hash) {
+      window.location.hash = hash
+    }
   }
 
   function NavItem({
@@ -39,7 +61,7 @@ export default function Sidebar() {
     return (
       <Link
         href={href}
-        onClick={handleNavigation}
+        onClick={(event) => handleHashClick(event, href)}
         className="flex items-center px-3 py-2 text-sm rounded-md transition-colors text-foreground/70 hover:text-foreground hover:bg-accent/60"
       >
         <Icon className="h-4 w-4 mr-3 flex-shrink-0" />


### PR DESCRIPTION
### Motivation
- Clicking sidebar links with hashes (e.g. `#ai-advisor`, `#goals`, `#transactions`) only scrolled to the target on the first click, and subsequent clicks did not update the view or re-trigger scrolling.
- The goal is to ensure clicking any section link always updates the URL hash and triggers navigation/scroll without breaking existing mobile menu behavior.

### Description
- Added `usePathname` from `next/navigation` and capture the current `pathname` to distinguish same-page hash links from full navigation in `components/kokonutui/sidebar.tsx`.
- Implemented `handleHashClick(event, href)` which prevents the default link behavior for same-page hashes, closes the mobile menu, and explicitly sets `window.location.hash` to force scroll into the target section.
- Replaced the previous `onClick={handleNavigation}` on `NavItem` with `onClick={(event) => handleHashClick(event, href)}` so all sidebar links (hash or normal) behave correctly while preserving mobile menu closure.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987f77d743c832b9c6b161bed133d0f)