### PR TITLE
Fix hash navigation scrolling across tabs and make sidebar hash clicks reliable

### DIFF
--- a/components/kokonutui/content.tsx
+++ b/components/kokonutui/content.tsx
@@ -44,6 +44,7 @@ export default function Content() {
   )
 
   const [tabValue, setTabValue] = useState("portfolio")
+  const [pendingHash, setPendingHash] = useState<string | null>(null)
 
   useEffect(() => {
     const syncTabWithHash = () => {
@@ -54,10 +55,7 @@ export default function Content() {
       const nextTab = sectionToTab[hash as keyof typeof sectionToTab]
       if (nextTab) {
         setTabValue(nextTab)
-        requestAnimationFrame(() => {
-          const target = document.getElementById(hash)
-          target?.scrollIntoView({ behavior: "smooth", block: "start" })
-        })
+        setPendingHash(hash)
       }
     }
 
@@ -67,6 +65,34 @@ export default function Content() {
       window.removeEventListener("hashchange", syncTabWithHash)
     }
   }, [sectionToTab])
+
+  useEffect(() => {
+    if (!pendingHash) {
+      return
+    }
+
+    const scrollToTarget = () => {
+      const target = document.getElementById(pendingHash)
+      if (target) {
+        target.scrollIntoView({ behavior: "smooth", block: "start" })
+        setPendingHash(null)
+        return true
+      }
+      return false
+    }
+
+    if (scrollToTarget()) {
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      scrollToTarget()
+    }, 100)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+    }
+  }, [pendingHash, tabValue])
 
   return (
     <PortfolioProvider>

--- a/components/kokonutui/sidebar.tsx
+++ b/components/kokonutui/sidebar.tsx
@@ -18,13 +18,35 @@ import {
   Plug,
 } from "lucide-react"
 import Link from "next/link"
+import { usePathname } from "next/navigation"
 import { useState } from "react"
 
 export default function Sidebar() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
+  const pathname = usePathname()
 
   function handleNavigation() {
     setIsMobileMenuOpen(false)
+  }
+
+  function handleHashClick(event: React.MouseEvent<HTMLAnchorElement>, href: string) {
+    if (!href.includes("#")) {
+      handleNavigation()
+      return
+    }
+
+    const [targetPath, hash] = href.split("#")
+    if (targetPath && targetPath !== pathname) {
+      handleNavigation()
+      return
+    }
+
+    event.preventDefault()
+    handleNavigation()
+
+    if (hash) {
+      window.location.hash = hash
+    }
   }
 
   function NavItem({
@@ -39,7 +61,7 @@ export default function Sidebar() {
     return (
       <Link
         href={href}
-        onClick={handleNavigation}
+        onClick={(event) => handleHashClick(event, href)}
         className="flex items-center px-3 py-2 text-sm rounded-md transition-colors text-foreground/70 hover:text-foreground hover:bg-accent/60"
       >
         <Icon className="h-4 w-4 mr-3 flex-shrink-0" />


### PR DESCRIPTION
### Motivation
- Sidebar links targeting in-page sections sometimes failed to scroll when the target lived in a different tab (e.g. switching from Portfolio to Planning) or when the same hash was clicked repeatedly.
- Navigation should still close the mobile menu and behave like normal links while ensuring the page scrolls to the requested section after the tab switch.

### Description
- Added `pendingHash` state in `components/kokonutui/content.tsx` to defer scrolling until the requested tab is active and the section is mounted.  
- Implemented a retry mechanism in a `useEffect` that attempts to `document.getElementById(pendingHash)?.scrollIntoView(...)` immediately and again after a short timeout if the element is not yet mounted.  
- Updated `components/kokonutui/sidebar.tsx` to use `usePathname` and added `handleHashClick(event, href)` which prevents default for same-page hash clicks, preserves mobile menu closing, and sets `window.location.hash` to force navigation when appropriate.  
- Replaced `NavItem`'s `onClick={handleNavigation}` with `onClick={(event) => handleHashClick(event, href)}` so normal links and same-page hash links both behave correctly and keep existing mobile menu behavior.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987f77d743c832b9c6b161bed133d0f)