### PR TITLE
Persist settings with localStorage and convert Settings page to controlled form

### DIFF
--- a/lib/settings-store.ts
+++ b/lib/settings-store.ts
@@ -1,0 +1,66 @@
+export type SettingsData = {
+  name: string
+  email: string
+  phone: string
+  notifications: {
+    weeklySummary: boolean
+    thresholdAlerts: boolean
+    mobileNotifications: boolean
+  }
+  language: string
+  currency: string
+  timezone: string
+}
+
+const STORAGE_KEY = "kokonutui.settings"
+
+export const defaultSettings: SettingsData = {
+  name: "",
+  email: "",
+  phone: "",
+  notifications: {
+    weeklySummary: true,
+    thresholdAlerts: false,
+    mobileNotifications: true,
+  },
+  language: "fr",
+  currency: "eur",
+  timezone: "paris",
+}
+
+const readStorage = (): SettingsData => {
+  if (typeof window === "undefined") {
+    return defaultSettings
+  }
+
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (!raw) {
+    return defaultSettings
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<SettingsData>
+    return {
+      ...defaultSettings,
+      ...parsed,
+      notifications: {
+        ...defaultSettings.notifications,
+        ...parsed.notifications,
+      },
+    }
+  } catch {
+    return defaultSettings
+  }
+}
+
+export const loadSettings = async (): Promise<SettingsData> => {
+  return readStorage()
+}
+
+export const saveSettings = async (settings: SettingsData): Promise<void> => {
+  if (typeof window === "undefined") {
+    return
+  }
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+}


### PR DESCRIPTION
### Motivation
- Provide a simple, local persistence for user settings (name, email, phone, notification prefs, language, currency, timezone). 
- Convert the Settings UI to controlled inputs so values can be hydrated and edited reliably.
- Add autosave/manual save flows and UX for loading/saving/error states.

### Description
- Add `lib/settings-store.ts` implementing `SettingsData`, `defaultSettings`, `loadSettings()` and `saveSettings()` using `localStorage` as the backing store.
- Update `app/settings/page.tsx` to use `useState` for `settings` and `status`, hydrate initial values with `loadSettings()` on mount, and handle load errors.
- Implement `persistSettings()` to call `saveSettings()` with status transitions (`saving`, `saved`, `error`) and a `statusCopy` message map for the UI.
- Convert inputs to controlled components (`value` + `onChange`) with autosave via `onBlur` for text fields and immediate persist on preference toggles/selects, and add a manual save `Button` (`Enregistrer`) and status/error indicator.

### Testing
- Started the dev server with `pnpm dev`, compiled the app and the `/settings` route successfully (compilation completed and `GET /settings` returned `200`); there were non-blocking font download warnings. — succeeded.
- Ran a Playwright script to open `http://127.0.0.1:3000/settings` and capture a screenshot, producing the artifact at `browser:/tmp/codex_browser_invocations/9ac28eb87adce84c/artifacts/artifacts/settings-page.png`. — succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69888f75117c832bbb1801ad0c6bdeab)