### PR TITLE
Add persisted notification workflow and scheduler

### DIFF
--- a/app/api/alerts/route.ts
+++ b/app/api/alerts/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server"
+import { addAlert, readNotificationStore, updateAlert } from "@/lib/notification-storage"
+
+export const GET = async () => {
+  const store = await readNotificationStore()
+  return NextResponse.json(store.alerts)
+}
+
+export const POST = async (request: Request) => {
+  const payload = (await request.json()) as Parameters<typeof addAlert>[0]
+  const alert = await addAlert(payload)
+  return NextResponse.json(alert)
+}
+
+export const PATCH = async (request: Request) => {
+  const payload = (await request.json()) as {
+    id: string
+    updates: Parameters<typeof updateAlert>[1]
+  }
+
+  const alert = await updateAlert(payload.id, payload.updates)
+  if (!alert) {
+    return NextResponse.json({ message: "Alert not found" }, { status: 404 })
+  }
+
+  return NextResponse.json(alert)
+}

--- a/app/api/notification-cron/route.ts
+++ b/app/api/notification-cron/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server"
+import { runNotificationScan } from "@/lib/notification-trigger"
+
+export const GET = async () => {
+  const result = await runNotificationScan()
+  return NextResponse.json(result)
+}
+
+export const POST = async () => {
+  const result = await runNotificationScan()
+  return NextResponse.json(result)
+}

--- a/app/api/notification-preferences/route.ts
+++ b/app/api/notification-preferences/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server"
+import { updatePreferences, readNotificationStore } from "@/lib/notification-storage"
+
+export const GET = async () => {
+  const store = await readNotificationStore()
+  return NextResponse.json(store.preferences)
+}
+
+export const PUT = async (request: Request) => {
+  const payload = (await request.json()) as Parameters<typeof updatePreferences>[0]
+  const preferences = await updatePreferences(payload)
+  return NextResponse.json(preferences)
+}

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server"
+import { addTask, readNotificationStore, updateTask } from "@/lib/notification-storage"
+
+export const GET = async () => {
+  const store = await readNotificationStore()
+  return NextResponse.json(store.tasks)
+}
+
+export const POST = async (request: Request) => {
+  const payload = (await request.json()) as Parameters<typeof addTask>[0]
+  const task = await addTask(payload)
+  return NextResponse.json(task)
+}
+
+export const PATCH = async (request: Request) => {
+  const payload = (await request.json()) as {
+    id: string
+    updates: Parameters<typeof updateTask>[1]
+  }
+
+  const task = await updateTask(payload.id, payload.updates)
+  if (!task) {
+    return NextResponse.json({ message: "Task not found" }, { status: 404 })
+  }
+
+  return NextResponse.json(task)
+}

--- a/lib/notification-client.ts
+++ b/lib/notification-client.ts
@@ -1,0 +1,77 @@
+import type {
+  AlertItem,
+  NotificationPreferences,
+  TaskItem,
+} from "@/lib/notification-types"
+
+const fetchJson = async <T>(input: RequestInfo, init?: RequestInit): Promise<T> => {
+  const response = await fetch(input, init)
+  if (!response.ok) {
+    throw new Error("Erreur réseau")
+  }
+  return response.json() as Promise<T>
+}
+
+export const getTasks = async (): Promise<TaskItem[]> => {
+  return fetchJson<TaskItem[]>("/api/tasks")
+}
+
+export const createTask = async (
+  task: Omit<TaskItem, "id" | "createdAt" | "updatedAt">
+): Promise<TaskItem> => {
+  return fetchJson<TaskItem>("/api/tasks", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(task),
+  })
+}
+
+export const updateTask = async (
+  id: string,
+  updates: Partial<Omit<TaskItem, "id" | "createdAt">>
+): Promise<TaskItem> => {
+  return fetchJson<TaskItem>("/api/tasks", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ id, updates }),
+  })
+}
+
+export const getAlerts = async (): Promise<AlertItem[]> => {
+  return fetchJson<AlertItem[]>("/api/alerts")
+}
+
+export const createAlert = async (
+  alert: Omit<AlertItem, "id" | "createdAt" | "updatedAt">
+): Promise<AlertItem> => {
+  return fetchJson<AlertItem>("/api/alerts", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(alert),
+  })
+}
+
+export const updateAlert = async (
+  id: string,
+  updates: Partial<Omit<AlertItem, "id" | "createdAt">>
+): Promise<AlertItem> => {
+  return fetchJson<AlertItem>("/api/alerts", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ id, updates }),
+  })
+}
+
+export const getNotificationPreferences = async (): Promise<NotificationPreferences> => {
+  return fetchJson<NotificationPreferences>("/api/notification-preferences")
+}
+
+export const saveNotificationPreferences = async (
+  preferences: NotificationPreferences
+): Promise<NotificationPreferences> => {
+  return fetchJson<NotificationPreferences>("/api/notification-preferences", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(preferences),
+  })
+}

--- a/lib/notification-dispatcher.ts
+++ b/lib/notification-dispatcher.ts
@@ -1,0 +1,52 @@
+import type { AlertItem, NotificationPreferences, TaskItem } from "@/lib/notification-types"
+import { resolveNotificationChannels } from "@/lib/notification-scheduler"
+
+export type NotificationDispatchPayload = {
+  id: string
+  title: string
+  description: string
+  channels: {
+    email: boolean
+    push: boolean
+  }
+  triggeredAt: string
+  source: "task" | "alert"
+}
+
+export const dispatchTaskNotification = (
+  task: TaskItem,
+  preferences: NotificationPreferences
+): NotificationDispatchPayload => {
+  const channels = resolveNotificationChannels(preferences, {
+    channelEmail: task.channelEmail,
+    channelPush: task.channelPush,
+  })
+
+  return {
+    id: task.id,
+    title: `Rappel: ${task.title}`,
+    description: task.notes || "Tâche planifiée",
+    channels,
+    triggeredAt: new Date().toISOString(),
+    source: "task",
+  }
+}
+
+export const dispatchAlertNotification = (
+  alert: AlertItem,
+  preferences: NotificationPreferences
+): NotificationDispatchPayload => {
+  const channels = resolveNotificationChannels(preferences, {
+    channelEmail: alert.channelEmail,
+    channelPush: alert.channelPush,
+  })
+
+  return {
+    id: alert.id,
+    title: `Alerte: ${alert.title}`,
+    description: `${alert.metric} · Seuil ${alert.threshold}`,
+    channels,
+    triggeredAt: new Date().toISOString(),
+    source: "alert",
+  }
+}

--- a/lib/notification-preferences.ts
+++ b/lib/notification-preferences.ts
@@ -1,0 +1,38 @@
+import { defaultNotificationPreferences, type NotificationPreferences } from "@/lib/notification-types"
+
+const STORAGE_KEY = "kokonutui.notification-preferences"
+
+const readPreferences = (): NotificationPreferences => {
+  if (typeof window === "undefined") {
+    return defaultNotificationPreferences
+  }
+
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (!raw) {
+    return defaultNotificationPreferences
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<NotificationPreferences>
+    return {
+      ...defaultNotificationPreferences,
+      ...parsed,
+    }
+  } catch {
+    return defaultNotificationPreferences
+  }
+}
+
+export const loadNotificationPreferences = async (): Promise<NotificationPreferences> => {
+  return readPreferences()
+}
+
+export const saveNotificationPreferences = async (
+  preferences: NotificationPreferences
+): Promise<void> => {
+  if (typeof window === "undefined") {
+    return
+  }
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences))
+}

--- a/lib/notification-scheduler.ts
+++ b/lib/notification-scheduler.ts
@@ -1,0 +1,95 @@
+import type { AlertItem, NotificationPreferences, TaskItem } from "@/lib/notification-types"
+
+const REMINDER_OFFSETS: Record<string, number> = {
+  "1 heure avant": 60 * 60 * 1000,
+  "24 heures avant": 24 * 60 * 60 * 1000,
+  "1 semaine avant": 7 * 24 * 60 * 60 * 1000,
+}
+
+const CADENCE_OFFSETS: Record<string, number> = {
+  Quotidien: 24 * 60 * 60 * 1000,
+  Hebdomadaire: 7 * 24 * 60 * 60 * 1000,
+  Mensuel: 30 * 24 * 60 * 60 * 1000,
+}
+
+export type ResolvedChannels = {
+  email: boolean
+  push: boolean
+}
+
+export const resolveNotificationChannels = (
+  preferences: NotificationPreferences,
+  overrides?: { channelEmail?: boolean; channelPush?: boolean }
+): ResolvedChannels => {
+  return {
+    email: overrides?.channelEmail ?? preferences.email,
+    push: overrides?.channelPush ?? preferences.push,
+  }
+}
+
+const getDueDateTime = (dueDate: string): Date | null => {
+  if (!dueDate) {
+    return null
+  }
+
+  const date = new Date(`${dueDate}T09:00:00`)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  return date
+}
+
+export const getNextTaskNotificationAt = (task: TaskItem, now: Date): Date | null => {
+  if (task.completed || task.reminder === "Aucun") {
+    return null
+  }
+
+  const dueDateTime = getDueDateTime(task.dueDate)
+  if (!dueDateTime) {
+    return null
+  }
+
+  const offset = REMINDER_OFFSETS[task.reminder] ?? 0
+  const reminderTime = new Date(dueDateTime.getTime() - offset)
+
+  if (reminderTime.getTime() > now.getTime()) {
+    return reminderTime
+  }
+
+  if (dueDateTime.getTime() > now.getTime()) {
+    return now
+  }
+
+  return null
+}
+
+export const getNextAlertNotificationAt = (alert: AlertItem, now: Date): Date | null => {
+  if (alert.cadence === "Temps réel") {
+    return now
+  }
+
+  const cadenceOffset = CADENCE_OFFSETS[alert.cadence]
+  if (!cadenceOffset) {
+    return now
+  }
+
+  if (!alert.lastNotifiedAt) {
+    return now
+  }
+
+  const lastNotifiedDate = new Date(alert.lastNotifiedAt)
+  if (Number.isNaN(lastNotifiedDate.getTime())) {
+    return now
+  }
+
+  const next = new Date(lastNotifiedDate.getTime() + cadenceOffset)
+  return next.getTime() > now.getTime() ? next : now
+}
+
+export const formatNotificationDate = (date: Date): string => {
+  return date.toLocaleString("fr-FR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  })
+}

--- a/lib/notification-storage.ts
+++ b/lib/notification-storage.ts
@@ -1,0 +1,206 @@
+import { promises as fs } from "fs"
+import path from "path"
+import {
+  cadenceOptions,
+  defaultNotificationPreferences,
+  reminderOptions,
+  type AlertItem,
+  type NotificationStore,
+  type TaskItem,
+} from "@/lib/notification-types"
+
+const DATA_DIR = path.join(process.cwd(), "data")
+const DATA_PATH = path.join(DATA_DIR, "notifications.json")
+
+const createSeedTask = (overrides: Partial<TaskItem>): TaskItem => {
+  const now = new Date().toISOString()
+  return {
+    id: overrides.id ?? `task-${Date.now()}`,
+    title: overrides.title ?? "Nouvelle tâche",
+    dueDate: overrides.dueDate ?? "",
+    reminder: overrides.reminder ?? reminderOptions[0],
+    notes: overrides.notes ?? "",
+    channelEmail: overrides.channelEmail ?? true,
+    channelPush: overrides.channelPush ?? true,
+    completed: overrides.completed ?? false,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    lastNotifiedAt: overrides.lastNotifiedAt ?? null,
+  }
+}
+
+const createSeedAlert = (overrides: Partial<AlertItem>): AlertItem => {
+  const now = new Date().toISOString()
+  return {
+    id: overrides.id ?? `alert-${Date.now()}`,
+    title: overrides.title ?? "Nouvelle alerte",
+    metric: overrides.metric ?? "Allocation",
+    threshold: overrides.threshold ?? "",
+    cadence: overrides.cadence ?? cadenceOptions[0],
+    channelEmail: overrides.channelEmail ?? true,
+    channelPush: overrides.channelPush ?? true,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    lastNotifiedAt: overrides.lastNotifiedAt ?? null,
+  }
+}
+
+const seedStore: NotificationStore = {
+  preferences: defaultNotificationPreferences,
+  tasks: [
+    createSeedTask({
+      id: "task-1",
+      title: "Rebalancer le portefeuille",
+      dueDate: "2024-08-28",
+      reminder: "24 heures avant",
+      notes: "Confirmer l'impact fiscal avant l'arbitrage.",
+      channelEmail: true,
+      channelPush: true,
+    }),
+    createSeedTask({
+      id: "task-2",
+      title: "Rapprocher les dividendes",
+      dueDate: "2024-09-02",
+      reminder: "1 semaine avant",
+      notes: "Comparer avec les prévisions trimestrielles.",
+      channelEmail: true,
+      channelPush: false,
+    }),
+  ],
+  alerts: [
+    createSeedAlert({
+      id: "alert-1",
+      title: "Seuil de volatilité",
+      metric: "Risque",
+      threshold: "> 12%",
+      cadence: "Temps réel",
+      channelEmail: true,
+      channelPush: true,
+    }),
+    createSeedAlert({
+      id: "alert-2",
+      title: "Liquidité minimale",
+      metric: "Cash",
+      threshold: "< 15 000 €",
+      cadence: "Quotidien",
+      channelEmail: true,
+      channelPush: false,
+    }),
+  ],
+}
+
+const ensureStoreFile = async (): Promise<void> => {
+  try {
+    await fs.access(DATA_PATH)
+  } catch {
+    await fs.mkdir(DATA_DIR, { recursive: true })
+    await fs.writeFile(DATA_PATH, JSON.stringify(seedStore, null, 2), "utf-8")
+  }
+}
+
+export const readNotificationStore = async (): Promise<NotificationStore> => {
+  await ensureStoreFile()
+  const raw = await fs.readFile(DATA_PATH, "utf-8")
+  try {
+    const parsed = JSON.parse(raw) as Partial<NotificationStore>
+    return {
+      preferences: {
+        ...defaultNotificationPreferences,
+        ...parsed.preferences,
+      },
+      tasks: parsed.tasks ?? seedStore.tasks,
+      alerts: parsed.alerts ?? seedStore.alerts,
+    }
+  } catch {
+    return seedStore
+  }
+}
+
+export const writeNotificationStore = async (store: NotificationStore): Promise<void> => {
+  await fs.mkdir(DATA_DIR, { recursive: true })
+  await fs.writeFile(DATA_PATH, JSON.stringify(store, null, 2), "utf-8")
+}
+
+export const addTask = async (input: Omit<TaskItem, "id" | "createdAt" | "updatedAt">) => {
+  const store = await readNotificationStore()
+  const now = new Date().toISOString()
+  const task: TaskItem = {
+    ...input,
+    id: `task-${Date.now()}`,
+    createdAt: now,
+    updatedAt: now,
+  }
+  store.tasks = [task, ...store.tasks]
+  await writeNotificationStore(store)
+  return task
+}
+
+export const updateTask = async (
+  id: string,
+  updates: Partial<Omit<TaskItem, "id" | "createdAt">>
+) => {
+  const store = await readNotificationStore()
+  const now = new Date().toISOString()
+  let updatedTask: TaskItem | null = null
+  store.tasks = store.tasks.map((task) => {
+    if (task.id !== id) {
+      return task
+    }
+    updatedTask = {
+      ...task,
+      ...updates,
+      updatedAt: now,
+    }
+    return updatedTask
+  })
+  await writeNotificationStore(store)
+  return updatedTask
+}
+
+export const addAlert = async (
+  input: Omit<AlertItem, "id" | "createdAt" | "updatedAt">
+) => {
+  const store = await readNotificationStore()
+  const now = new Date().toISOString()
+  const alert: AlertItem = {
+    ...input,
+    id: `alert-${Date.now()}`,
+    createdAt: now,
+    updatedAt: now,
+  }
+  store.alerts = [alert, ...store.alerts]
+  await writeNotificationStore(store)
+  return alert
+}
+
+export const updateAlert = async (
+  id: string,
+  updates: Partial<Omit<AlertItem, "id" | "createdAt">>
+) => {
+  const store = await readNotificationStore()
+  const now = new Date().toISOString()
+  let updatedAlert: AlertItem | null = null
+  store.alerts = store.alerts.map((alert) => {
+    if (alert.id !== id) {
+      return alert
+    }
+    updatedAlert = {
+      ...alert,
+      ...updates,
+      updatedAt: now,
+    }
+    return updatedAlert
+  })
+  await writeNotificationStore(store)
+  return updatedAlert
+}
+
+export const updatePreferences = async (preferences: NotificationStore["preferences"]) => {
+  const store = await readNotificationStore()
+  store.preferences = {
+    ...store.preferences,
+    ...preferences,
+  }
+  await writeNotificationStore(store)
+  return store.preferences
+}

--- a/lib/notification-trigger.ts
+++ b/lib/notification-trigger.ts
@@ -1,0 +1,54 @@
+import {
+  dispatchAlertNotification,
+  dispatchTaskNotification,
+  type NotificationDispatchPayload,
+} from "@/lib/notification-dispatcher"
+import {
+  getNextAlertNotificationAt,
+  getNextTaskNotificationAt,
+} from "@/lib/notification-scheduler"
+import {
+  readNotificationStore,
+  updateAlert,
+  updateTask,
+} from "@/lib/notification-storage"
+
+export type NotificationScanResult = {
+  triggered: NotificationDispatchPayload[]
+}
+
+export const runNotificationScan = async (): Promise<NotificationScanResult> => {
+  const store = await readNotificationStore()
+  const now = new Date()
+  const triggered: NotificationDispatchPayload[] = []
+
+  for (const task of store.tasks) {
+    const nextAt = getNextTaskNotificationAt(task, now)
+    if (!nextAt) {
+      continue
+    }
+    const lastNotified = task.lastNotifiedAt ? new Date(task.lastNotifiedAt) : null
+    if (lastNotified && lastNotified.getTime() >= nextAt.getTime()) {
+      continue
+    }
+
+    triggered.push(dispatchTaskNotification(task, store.preferences))
+    await updateTask(task.id, { lastNotifiedAt: now.toISOString() })
+  }
+
+  for (const alert of store.alerts) {
+    const nextAt = getNextAlertNotificationAt(alert, now)
+    if (!nextAt) {
+      continue
+    }
+    const lastNotified = alert.lastNotifiedAt ? new Date(alert.lastNotifiedAt) : null
+    if (lastNotified && lastNotified.getTime() >= nextAt.getTime()) {
+      continue
+    }
+
+    triggered.push(dispatchAlertNotification(alert, store.preferences))
+    await updateAlert(alert.id, { lastNotifiedAt: now.toISOString() })
+  }
+
+  return { triggered }
+}

--- a/lib/notification-types.ts
+++ b/lib/notification-types.ts
@@ -1,0 +1,46 @@
+export type NotificationPreferences = {
+  email: boolean
+  push: boolean
+}
+
+export type TaskItem = {
+  id: string
+  title: string
+  dueDate: string
+  reminder: string
+  notes: string
+  channelEmail?: boolean
+  channelPush?: boolean
+  completed: boolean
+  createdAt: string
+  updatedAt: string
+  lastNotifiedAt?: string | null
+}
+
+export type AlertItem = {
+  id: string
+  title: string
+  metric: string
+  threshold: string
+  cadence: string
+  channelEmail?: boolean
+  channelPush?: boolean
+  createdAt: string
+  updatedAt: string
+  lastNotifiedAt?: string | null
+}
+
+export type NotificationStore = {
+  tasks: TaskItem[]
+  alerts: AlertItem[]
+  preferences: NotificationPreferences
+}
+
+export const reminderOptions = ["Aucun", "1 heure avant", "24 heures avant", "1 semaine avant"]
+
+export const cadenceOptions = ["Temps réel", "Quotidien", "Hebdomadaire", "Mensuel"]
+
+export const defaultNotificationPreferences: NotificationPreferences = {
+  email: true,
+  push: true,
+}


### PR DESCRIPTION
### Motivation
- Centraliser et persister les préférences de notification, tâches et alertes pour fournir un état partagé au-delà d'un `useState` local et permettre un dispatch/scan côté serveur.
- Fournir une logique de résolution de canaux et d'ordonnancement pour déclencher les notifications (rappels temporels et cadence d'alertes) de façon fiable.
- Exposer des API pour gérer tasks/alerts/preferences et un endpoint cron/trigger pour scanner et produire les notifications planifiées.

### Description
- Ajout de types et constantes partagés dans `lib/notification-types.ts` et d'un client HTTP `lib/notification-client.ts` pour consommer les routes API depuis le front-end.
- Implémentation du stockage persisté dans `lib/notification-storage.ts` (fichier `data/notifications.json` seedé), avec routes API Next.js `app/api/tasks`, `app/api/alerts` et `app/api/notification-preferences` pour CRUD basique.
- Ajout d'un ordonnanceur et utilitaires dans `lib/notification-scheduler.ts` pour calculer les prochains déclenchements et résoudre les canaux, et d'un dispatcher dans `lib/notification-dispatcher.ts` pour construire la payload de notification.
- Ajout d'un scanner/trigger `lib/notification-trigger.ts` et d'une route `app/api/notification-cron/route.ts` qui exécute le scan et marque `lastNotifiedAt` quand des notifications sont déclenchées.
- Mise à jour de l'UI `components/kokonutui/alerts-notifications.tsx` pour charger les préférences/tâches/alertes via l'API, afficher les notifications planifiées et permettre la gestion des préférences globales et la création/édition persistée des items.

### Testing
- Démarré le serveur de développement avec `pnpm exec next dev -H 0.0.0.0 -p 3000` et la page s'est compilée et chargée (Next.js ready). 
- Exécution d'un script Playwright qui a chargé `http://127.0.0.1:3000/planning/alerts-notifications` et généré une capture d'écran (artifact `artifacts/alerts-notifications.png`) confirmant le rendu de la nouvelle UI. 
- Les endpoints API consultés par l'UI (`GET /api/alerts`, `GET /api/tasks`, `GET /api/notification-preferences`) ont répondu `200` lors du test d'intégration dans le navigateur; la compilation a renvoyé des avertissements de téléchargement de polices Google Fonts mais la page s'est rendue avec des polices de secours. 
- Aucun test unitaire automatisé additionnel n'a été ajouté.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ae1e5794832b93aefeafbb1a7e90)