### PR TITLE
Rename project to OpenNova-Finance and add GitHub repository metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Quantum Finance Dashboard
+# OpenNova-Finance
 
 Modern financial dashboard with AI-powered insights, portfolio tracking, and a futuristic UI.
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ const geistSans = Geist({ subsets: ["latin"], variable: "--font-geist-sans" })
 const geistMono = Geist_Mono({ subsets: ["latin"], variable: "--font-geist-mono" })
 
 export const metadata = {
-  title: "KokonutUI Dashboard",
+  title: "OpenNova-Finance",
   description: "A modern dashboard with theme switching",
   generator: "v0.app",
 }
@@ -26,4 +26,3 @@ export default function RootLayout({
     </html>
   )
 }
-

--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
-  "name": "my-v0-project",
+  "name": "open-nova-finance",
   "version": "0.1.0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/OpenNova-Finance/OpenNova-Finance.git"
+  },
+  "homepage": "https://github.com/OpenNova-Finance/OpenNova-Finance",
   "scripts": {
     "build": "next build",
     "dev": "next dev",


### PR DESCRIPTION
### Motivation
- Consolidate project branding by renaming runtime and documentation metadata to "OpenNova-Finance".
- Ensure UI/SEO runtime metadata reflects the new project name for consistency.
- Publish accurate project repository information in package metadata so package managers and GitHub links point to the renamed repo.

### Description
- Updated the top-level title in `README.md` from the previous name to `OpenNova-Finance`.
- Set the Next.js metadata `title` in `app/layout.tsx` to `"OpenNova-Finance"` for runtime UI/SEO consistency.
- Changed the `name` field in `package.json` to `"open-nova-finance"` to match the repo rename.
- Added `repository` and `homepage` entries to `package.json` with the URL `https://github.com/OpenNova-Finance/OpenNova-Finance`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69891cfb0e54832bb0b998290f99e701)