### PR TITLE
Rebrand InvestAI to OpenNova-Finance and update project metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Quantum Finance Dashboard
+# OpenNova-Finance
 
 Modern financial dashboard with AI-powered insights, portfolio tracking, and a futuristic UI.
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ const geistSans = Geist({ subsets: ["latin"], variable: "--font-geist-sans" })
 const geistMono = Geist_Mono({ subsets: ["latin"], variable: "--font-geist-mono" })
 
 export const metadata = {
-  title: "KokonutUI Dashboard",
+  title: "OpenNova-Finance",
   description: "A modern dashboard with theme switching",
   generator: "v0.app",
 }
@@ -26,4 +26,3 @@ export default function RootLayout({
     </html>
   )
 }
-

--- a/components/kokonutui/sidebar.tsx
+++ b/components/kokonutui/sidebar.tsx
@@ -154,7 +154,7 @@ export default function Sidebar() {
               <div className="p-2 rounded-xl border border-border/60 bg-primary/10">
                 <TrendingUp className="h-5 w-5 text-primary" />
               </div>
-              <span className="text-lg font-semibold tracking-tight fx-brand">InvestAI</span>
+              <span className="text-lg font-semibold tracking-tight fx-brand">OpenNova-Finance</span>
             </div>
           </div>
 

--- a/components/kokonutui/top-nav.tsx
+++ b/components/kokonutui/top-nav.tsx
@@ -15,7 +15,7 @@ interface BreadcrumbItem {
 
 export default function TopNav() {
   const breadcrumbs: BreadcrumbItem[] = [
-    { label: "InvestAI", href: "#" },
+    { label: "OpenNova-Finance", href: "#" },
     { label: "Dashboard", href: "#" },
   ]
   const criticalAlerts = ALERTS.filter((alert) => alert.status === "critique").length

--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
-  "name": "my-v0-project",
+  "name": "open-nova-finance",
   "version": "0.1.0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LazyBacO/OpenNova-Finance.git"
+  },
+  "homepage": "https://github.com/LazyBacO/OpenNova-Finance",
   "scripts": {
     "build": "next build",
     "dev": "next dev",


### PR DESCRIPTION
### Motivation
- Consolidate project branding so documentation, package metadata, and UI all present `OpenNova-Finance` as the official project name.
- Replace residual in-app label `InvestAI` with the new brand so the runtime UI matches the renamed repository and package metadata.

### Description
- Updated the README title by replacing `Quantum Finance Dashboard` with `OpenNova-Finance` in `README.md`.
- Set the application metadata `title` to `OpenNova-Finance` in `app/layout.tsx`.
- Updated `package.json` to set the package `name` to `open-nova-finance` and added `repository.url` and `homepage` pointing to `https://github.com/LazyBacO/OpenNova-Finance`.
- Replaced `InvestAI` with `OpenNova-Finance` in the UI by editing `components/kokonutui/top-nav.tsx` and `components/kokonutui/sidebar.tsx`.

### Testing
- Searched the codebase for `InvestAI` with `rg` to locate and confirm all occurrences were updated successfully.
- Started the Next.js development server with `pnpm dev --hostname 0.0.0.0 --port 3000` and verified Next.js reported `Ready` and served on `http://localhost:3000`.
- Attempted an automated Playwright screenshot to capture the running app but the Chromium process crashed and the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69891cfb0e54832bb0b998290f99e701)