### PR TITLE
fix: harden notification preferences storage handling

### DIFF
--- a/lib/notification-preferences.ts
+++ b/lib/notification-preferences.ts
@@ -1,24 +1,28 @@
 import { defaultNotificationPreferences, type NotificationPreferences } from "@/lib/notification-types"
 
-const STORAGE_KEY = "kokonutui.notification-preferences"
+export const NOTIFICATION_PREFERENCES_STORAGE_KEY = "kokonutui.notification-preferences"
+
+const normalizePreferences = (value: Partial<NotificationPreferences>): NotificationPreferences => ({
+  email:
+    typeof value.email === "boolean" ? value.email : defaultNotificationPreferences.email,
+  push: typeof value.push === "boolean" ? value.push : defaultNotificationPreferences.push,
+})
 
 const readPreferences = (): NotificationPreferences => {
   if (typeof window === "undefined") {
     return defaultNotificationPreferences
   }
 
-  const raw = window.localStorage.getItem(STORAGE_KEY)
-  if (!raw) {
-    return defaultNotificationPreferences
-  }
-
   try {
-    const parsed = JSON.parse(raw) as Partial<NotificationPreferences>
-    return {
-      ...defaultNotificationPreferences,
-      ...parsed,
+    const raw = window.localStorage.getItem(NOTIFICATION_PREFERENCES_STORAGE_KEY)
+    if (!raw) {
+      return defaultNotificationPreferences
     }
+
+    const parsed = JSON.parse(raw) as Partial<NotificationPreferences>
+    return normalizePreferences(parsed)
   } catch {
+    // localStorage access can fail in private mode, blocked storage, or embedded webviews.
     return defaultNotificationPreferences
   }
 }
@@ -34,5 +38,12 @@ export const saveNotificationPreferences = async (
     return
   }
 
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences))
+  try {
+    window.localStorage.setItem(
+      NOTIFICATION_PREFERENCES_STORAGE_KEY,
+      JSON.stringify(normalizePreferences(preferences)),
+    )
+  } catch {
+    // Ignore storage write failures to keep settings interactions non-blocking.
+  }
 }

--- a/tests/notification-preferences.test.ts
+++ b/tests/notification-preferences.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import {
+  loadNotificationPreferences,
+  NOTIFICATION_PREFERENCES_STORAGE_KEY,
+  saveNotificationPreferences,
+} from "@/lib/notification-preferences"
+import { defaultNotificationPreferences } from "@/lib/notification-types"
+
+type WindowWithStorage = Window & {
+  localStorage: Storage
+}
+
+function makeStorage(overrides: {
+  getItem?: (key: string) => string | null
+  setItem?: (key: string, value: string) => void
+}): Storage {
+  return {
+    length: 0,
+    clear: () => {},
+    key: () => null,
+    removeItem: () => {},
+    getItem: overrides.getItem ?? (() => null),
+    setItem: overrides.setItem ?? (() => {}),
+  }
+}
+
+const installWindow = (storage: WindowWithStorage["localStorage"]) => {
+  Object.defineProperty(globalThis, "window", {
+    value: { localStorage: storage },
+    configurable: true,
+    writable: true,
+  })
+}
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "window", {
+    value: undefined,
+    configurable: true,
+    writable: true,
+  })
+})
+
+describe("notification-preferences storage resilience", () => {
+  it("returns defaults when localStorage access throws", async () => {
+    installWindow(
+      makeStorage({
+        getItem: () => {
+          throw new Error("SecurityError")
+        },
+      }),
+    )
+
+    await expect(loadNotificationPreferences()).resolves.toEqual(defaultNotificationPreferences)
+  })
+
+  it("does not throw when localStorage write fails", async () => {
+    installWindow(
+      makeStorage({
+        setItem: () => {
+          throw new Error("QuotaExceededError")
+        },
+      }),
+    )
+
+    await expect(saveNotificationPreferences(defaultNotificationPreferences)).resolves.toBeUndefined()
+  })
+
+  it("normalizes malformed persisted values", async () => {
+    installWindow(
+      makeStorage({
+        getItem: (key: string) => {
+          if (key !== NOTIFICATION_PREFERENCES_STORAGE_KEY) {
+            return null
+          }
+
+          return JSON.stringify({ email: "yes", push: false })
+        },
+      }),
+    )
+
+    await expect(loadNotificationPreferences()).resolves.toEqual({
+      email: true,
+      push: false,
+    })
+  })
+})


### PR DESCRIPTION
## Summary\n- harden lib/notification-preferences.ts against localStorage read/write failures\n- normalize preference payload to strict booleans for mail/push\n- export storage key for better testability\n- add targeted tests (	ests/notification-preferences.test.ts)\n\n## Validation\n- pnpm test tests/notification-preferences.test.ts (3/3 pass)\n